### PR TITLE
add missing header to compile QGIS

### DIFF
--- a/src/tile/ThreadPool.hpp
+++ b/src/tile/ThreadPool.hpp
@@ -38,6 +38,7 @@
 #include <condition_variable>
 #include <functional>
 #include <queue>
+#include <string>
 #include <thread>
 
 //#include "Common.hpp"


### PR DESCRIPTION
Without the header for `string`, QGIS fails to build in fedora. See https://github.com/qgis/QGIS/pull/52464