### PR TITLE
Adding option to build_vpc to read files from input file list

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ To create a virtual point cloud:
 pdal_wrench build_vpc --output=hello.vpc data1.las data2.las data3.las
 ```
 
+Or, if the inputs are listed in a text file:
+```
+data1.las
+data2.las
+data3.las
+```
+
+You can provide that file as input:
+```
+pdal_wrench build_vpc --output=hello.vpc --input-file-list=inputs.txt
+```
+
 Afterwards, other algorithms can be applied to a VPC:
 ```
 pdal_wrench clip --input=hello.vpc --polygon=clip.gpkg --output=hello_clipped.vpc

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -26,7 +26,6 @@ namespace fs = std::filesystem;
 #include "nlohmann/json.hpp"
 
 
-
 using json = nlohmann::json;
 
 using namespace pdal;
@@ -403,14 +402,16 @@ void buildVpc(std::vector<std::string> args)
     bool overview = false;
     int max_threads = -1;
     bool verbose = false;
+    bool help = false;
 
     ProgramArgs programArgs;
+    programArgs.add("help,h", "Output command help.", help);
     programArgs.add("output,o", "Output virtual point cloud file", outputFile);
     programArgs.add("files,f", "input files", inputFiles).setPositional();
+    programArgs.add("input-file-list", "Read input files from a txt file, one file per line.", inputFileList);
     programArgs.add("boundary", "Calculate boundary polygons from data", boundaries);
     programArgs.add("stats", "Calculate statistics from data", stats);
     programArgs.add("overview", "Create overview point cloud from source data", overview);
-    programArgs.add("input_file_list", "Read input files from a txt file, one file per line.", inputFileList);
 
     pdal::Arg& argThreads = programArgs.add("threads", "Max number of concurrent threads for parallel runs", max_threads);
     programArgs.add("verbose", "Print extra debugging output", verbose);
@@ -422,6 +423,14 @@ void buildVpc(std::vector<std::string> args)
     catch(pdal::arg_error err)
     {
         std::cerr << "failed to parse arguments: " << err.what() << std::endl;
+        return;
+    }
+
+    if (help)
+    {
+        
+        std::cout << "usage: pdal_wrench build_vpc [<args>]" << std::endl;
+        programArgs.dump(std::cerr, 2, Utils::screenWidth());
         return;
     }
 

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -11,6 +11,7 @@
  ****************************************************************************/
 
 #include <iostream>
+#include <fstream>
 #include <filesystem>
 #include <thread>
 namespace fs = std::filesystem;
@@ -395,6 +396,7 @@ std::string dateTimeStringFromYearAndDay(int year, int dayOfYear)
 void buildVpc(std::vector<std::string> args)
 {
     std::string outputFile;
+    std::string inputFileList;
     std::vector<std::string> inputFiles;
     bool boundaries = false;
     bool stats = false;
@@ -408,6 +410,7 @@ void buildVpc(std::vector<std::string> args)
     programArgs.add("boundary", "Calculate boundary polygons from data", boundaries);
     programArgs.add("stats", "Calculate statistics from data", stats);
     programArgs.add("overview", "Create overview point cloud from source data", overview);
+    programArgs.add("input_file_list", "Read input files from a txt file, one file per line.", inputFileList);
 
     pdal::Arg& argThreads = programArgs.add("threads", "Max number of concurrent threads for parallel runs", max_threads);
     programArgs.add("verbose", "Print extra debugging output", verbose);
@@ -420,6 +423,24 @@ void buildVpc(std::vector<std::string> args)
     {
         std::cerr << "failed to parse arguments: " << err.what() << std::endl;
         return;
+    }
+
+    if (!inputFileList.empty())
+    {
+        std::ifstream inputFile(inputFileList);
+        std::string line;
+
+        if(!inputFile)
+        {
+            std::cerr << "failed to open input file list: " << inputFileList << std::endl;
+            return;
+        }
+
+        while (std::getline(inputFile, line))
+        {
+            inputFiles.push_back(line);
+        }
+
     }
 
 //    std::cout << "input " << inputFiles.size() << std::endl;


### PR DESCRIPTION
Similar to `gdalbuildvrt` I wanted to read files from a text file:

```bash
pdal_wrench build_vpc --output=testing.vpc --input_file_list=lazlist.txt
```