### PR TITLE
add an option to read input data from a text file to tile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ pdal_wrench merge --output=merged.las --input-file-list=my_list.txt
 Creates tiles from input data. For example to get tiles sized 100x100:
 
 ```
-pdal_wrench tile --length=100 --output=/data/tiles --files=data1.las --files=data2.las --files=data3.las
+pdal_wrench tile --length=100 --output=/data/tiles data1.las data2.las data3.las
 ```
 
 This tool can also read input data from a text file (one file per line)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,13 @@ pdal_wrench merge --output=merged.las --input-file-list=my_list.txt
 Creates tiles from input data. For example to get tiles sized 100x100:
 
 ```
-pdal_wrench tile --length=100 --output=/data/tiles data1.las data2.las data3.las
+pdal_wrench tile --length=100 --output=/data/tiles --files=data1.las --files=data2.las --files=data3.las
+```
+
+This tool can also read input data from a text file (one file per line)
+
+```
+pdal_wrench tile --length=100 --output=/data/tiles --input-file-list=my_list.txt
 ```
 
 ## thin

--- a/src/tile/tile.cpp
+++ b/src/tile/tile.cpp
@@ -434,7 +434,7 @@ static void writeOutputFile(const std::string& filename, pdal::PointViewPtr view
 void addArgs(pdal::ProgramArgs& programArgs, BaseInfo::Options& options, pdal::Arg * &tempArg, pdal::Arg * &threadsArg)
 {
     programArgs.add("output,o", "Output directory/filename", options.outputDir);
-    programArgs.add("files,i", "Input files/directory", options.inputFiles);
+    programArgs.add("files,i", "Input files/directory", options.inputFiles).setPositional();
     programArgs.add("input-file-list", "Read input files from a text file", options.inputFileList);
     programArgs.add("length,l", "Tile length", options.tileLength, 1000.);
     tempArg = &(programArgs.add("temp_dir", "Temp directory", options.tempDir));
@@ -463,7 +463,7 @@ bool handleOptions(pdal::StringList& arglist, BaseInfo::Options& options)
     addArgs(programArgs, options, tempArg, threadsArg);
     try
     {
-        programArgs.parse(arglist);
+        programArgs.parseSimple(arglist);
     }
     catch (const pdal::arg_error& err)
     {

--- a/src/tile/tile.cpp
+++ b/src/tile/tile.cpp
@@ -124,6 +124,7 @@ public:
         int max_threads;
         std::string outputFormat;   // las or laz (for now)
         bool buildVpc = false;
+        std::string inputFileList; // file list with input files
     } opts;
 
     pdal::BOX3D trueBounds;
@@ -433,7 +434,8 @@ static void writeOutputFile(const std::string& filename, pdal::PointViewPtr view
 void addArgs(pdal::ProgramArgs& programArgs, BaseInfo::Options& options, pdal::Arg * &tempArg, pdal::Arg * &threadsArg)
 {
     programArgs.add("output,o", "Output directory/filename", options.outputDir);
-    programArgs.add("files,i", "Input files/directory", options.inputFiles).setPositional();
+    programArgs.add("files,i", "Input files/directory", options.inputFiles);
+    programArgs.add("input-file-list", "Read input files from a text file", options.inputFileList);
     programArgs.add("length,l", "Tile length", options.tileLength, 1000.);
     tempArg = &(programArgs.add("temp_dir", "Temp directory", options.tempDir));
     programArgs.add("output-format", "Output format (las/laz)", options.outputFormat);
@@ -497,6 +499,22 @@ bool handleOptions(pdal::StringList& arglist, BaseInfo::Options& options)
         if (options.outputFormat != "las" && options.outputFormat != "laz")
             throw FatalError("Unknown output format: " + options.outputFormat);
     }
+
+    if (!options.inputFileList.empty())
+    {
+        std::ifstream inputFile(options.inputFileList);
+        std::string line;
+        if(!inputFile)
+        {
+            throw FatalError("Failed to open input file list: " + options.inputFileList);
+        }
+
+        while (std::getline(inputFile, line))
+        {
+            options.inputFiles.push_back(line);
+        }
+    }
+
 
     return true;
 }


### PR DESCRIPTION
Add a `--input-file-list` option to 1tile` command. This option allows to read input point cloud files from a text file (one file per line) and can be handy when one needs to tile lots of files and/or when file paths are very long.