### PR TITLE
Fix merge copc

### DIFF
--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -156,6 +156,11 @@ void Merge::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipe
     tile.inputFilenames = inputFiles;
     tile.outputFilename = outputFile;
 
+    if (ends_with(outputFile, ".copc.laz"))
+    {
+        isStreaming = false;
+    }
+
     pipelines.push_back(pipeline(&tile));
 
     // only algs with single input have the number of points figured out already

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,28 @@ def _prepare_data():
 
     assert number_points == 338163
 
+    base_copc_data = utils.test_data_filepath("stadium-utm.copc.laz")
+
+    if not base_copc_data.exists():
+        res = subprocess.run(
+            [
+                utils.pdal_wrench_path(),
+                "translate",
+                f"--input={base_data.as_posix()}",
+                f"--output={base_copc_data.as_posix()}",
+            ],
+            check=True,
+        )
+
+        assert res.returncode == 0
+
+    assert base_copc_data.exists()
+
+    vpc = pdal.Reader.copc(base_copc_data.as_posix()).pipeline()
+    number_points = vpc.execute()
+
+    assert number_points == 693895
+
 
 @pytest.fixture
 def laz_files() -> typing.List[str]:
@@ -110,3 +132,9 @@ def main_laz_file() -> str:
 def vpc_file() -> str:
     "Return path to the vpc file"
     return utils.test_data_filepath("data.vpc").as_posix()
+
+
+@pytest.fixture
+def main_copc_file() -> str:
+    "Return path to the main copc file"
+    return utils.test_data_filepath("stadium-utm.copc.laz").as_posix()

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -1,0 +1,63 @@
+import subprocess
+
+import utils
+
+
+def test_boundary_laz(main_laz_file: str):
+    """Test boundary on las function"""
+
+    output = utils.test_data_filepath("boundary-laz.gpkg")
+
+    res = subprocess.run(
+        [
+            utils.pdal_wrench_path(),
+            "boundary",
+            f"--output={output.as_posix()}",
+            f"--input={main_laz_file}",
+        ],
+        check=True,
+    )
+
+    assert res.returncode == 0
+
+    assert output.exists()
+
+
+def test_boundary_copc(main_copc_file: str):
+    """Test boundary on copc function"""
+
+    output = utils.test_data_filepath("boundary_copc.gpkg")
+
+    res = subprocess.run(
+        [
+            utils.pdal_wrench_path(),
+            "boundary",
+            f"--output={output.as_posix()}",
+            f"--input={main_copc_file}",
+        ],
+        check=True,
+    )
+
+    assert res.returncode == 0
+
+    assert output.exists()
+
+
+def test_boundary_on_vpc(vpc_file: str):
+    """Test boundary on vpc function"""
+
+    output = utils.test_data_filepath("boundary-vpc.gpkg")
+
+    res = subprocess.run(
+        [
+            utils.pdal_wrench_path(),
+            "boundary",
+            f"--output={output.as_posix()}",
+            f"--input={vpc_file}",
+        ],
+        check=True,
+    )
+
+    assert res.returncode == 0
+
+    assert output.exists()

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -98,3 +98,30 @@ def test_clip_vpc_to_copc(vpc_file: str):
     number_of_points = pipeline.execute()
 
     assert number_of_points == 19983
+
+
+def test_clip_copc_to_laz(main_copc_file: str):
+    """Test clip las function"""
+
+    clipped_laz_file = utils.test_data_filepath("clipped-copc-input.laz")
+
+    res = subprocess.run(
+        [
+            utils.pdal_wrench_path(),
+            "clip",
+            f"--output={clipped_laz_file.as_posix()}",
+            f"--input={main_copc_file}",
+            f"--polygon={utils.test_data_filepath('rectangle1.gpkg')}",
+        ],
+        check=True,
+    )
+
+    assert res.returncode == 0
+
+    assert clipped_laz_file.exists()
+
+    pipeline = pdal.Reader(filename=clipped_laz_file.as_posix()).pipeline()
+
+    number_of_points = pipeline.execute()
+
+    assert number_of_points == 66832

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -80,3 +80,27 @@ def test_merge_vpc(vpc_file: str):
     assert isinstance(array[0]["Y"], np.float64)
     assert isinstance(array[0]["Z"], np.float64)
     assert isinstance(array[0]["Intensity"], np.uint16)
+
+
+def test_merge_to_copc(laz_files: typing.List[str]):
+    """Test merge to copc function"""
+
+    merged_copc_file = utils.test_data_filepath("data_merged.copc.laz")
+
+    res = subprocess.run(
+        [
+            utils.pdal_wrench_path(),
+            "merge",
+            f"--output={merged_copc_file.as_posix()}",
+            *laz_files,
+        ],
+        check=True,
+    )
+
+    assert res.returncode == 0
+
+    pipeline = pdal.Reader(filename=merged_copc_file.as_posix()).pipeline()
+
+    number_of_points = pipeline.execute()
+
+    assert number_of_points == 97965

--- a/tests/test_thin.py
+++ b/tests/test_thin.py
@@ -87,3 +87,31 @@ def test_thin_vpc_to_copc(vpc_file: str):
     number_of_points = pipeline.execute()
 
     assert number_of_points == 19593
+
+
+def test_thin_copc_to_laz(main_copc_file: str):
+    """Test thin copc to laz function"""
+
+    output = utils.test_data_filepath("thin-copc-input.laz")
+
+    res = subprocess.run(
+        [
+            utils.pdal_wrench_path(),
+            "thin",
+            "--mode=every-nth",
+            "--step-every-nth=5",
+            f"--input={main_copc_file}",
+            f"--output={output.as_posix()}",
+        ],
+        check=True,
+    )
+
+    assert res.returncode == 0
+
+    assert output.exists()
+
+    pipeline = pdal.Reader(filename=output.as_posix()).pipeline()
+
+    number_of_points = pipeline.execute()
+
+    assert number_of_points == 138779

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -81,3 +81,29 @@ def test_translate_vpc_to_copc(vpc_file: str):
     number_of_points = pipeline.execute()
 
     assert number_of_points == 97965
+
+
+def test_translate_copc_to_laz(main_copc_file: str):
+    """Test translate copc to copc function"""
+
+    output = utils.test_data_filepath("translate-copc-input.laz")
+
+    res = subprocess.run(
+        [
+            utils.pdal_wrench_path(),
+            "translate",
+            f"--input={main_copc_file}",
+            f"--output={output.as_posix()}",
+        ],
+        check=True,
+    )
+
+    assert res.returncode == 0
+
+    assert output.exists()
+
+    pipeline = pdal.Reader(filename=output.as_posix()).pipeline()
+
+    number_of_points = pipeline.execute()
+
+    assert number_of_points == 693895


### PR DESCRIPTION
If merge output is **copc.laz** then it cannot be in streaming mode.

Add some new tests cases mostly for **copc** inputs, just to be sure that they work.