### PR TITLE
Fix compilation with newer versions of PDAL

### DIFF
--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -16,14 +16,15 @@
 #include <thread>
 namespace fs = std::filesystem;
 
+// This include must precede any PDAL includes, to suppress its bundled JSON library.
+#include "nlohmann/json.hpp"
+
 #include "vpc.hpp"
 #include "utils.hpp"
 
 #include <pdal/Polygon.hpp>
 #include <pdal/Stage.hpp>
 #include <pdal/util/ProgramArgs.hpp>
-
-#include "nlohmann/json.hpp"
 
 
 using json = nlohmann::json;


### PR DESCRIPTION
Currently building `pdal_wrench` is broken when using PDAL from `master` (28e77b0608795c087bf2ca8ff0906d2d22270bd5). This PR "fixes" the build by moving around includes, as suggested by https://github.com/PDAL/PDAL/pull/4706#issuecomment-2878243958.

This is also needed to fix QGIS: https://github.com/qgis/QGIS/issues/61670

Personally, I think we should stop embedding `nlohmann/json` everywhere, but that's for later discussion.