### PR TITLE
Fix issues 

### DIFF
--- a/src/alg.cpp
+++ b/src/alg.cpp
@@ -173,3 +173,15 @@ void removeFiles(const std::vector<std::string> &tileOutputFiles, bool removePar
         fs::remove(outputDir);
     }
 }
+
+fs::path fileStem(const std::string &filename)
+{
+    fs::path inputBasename = fs::path(filename).stem();
+            
+    while(inputBasename.has_extension())
+    {
+        inputBasename = inputBasename.stem(); 
+    }
+
+    return inputBasename;
+}

--- a/src/alg.hpp
+++ b/src/alg.hpp
@@ -93,6 +93,8 @@ bool runAlg(std::vector<std::string> args, Alg &alg);
 
 void removeFiles(const std::vector<std::string> &tileOutputFiles, bool removeParentDirIfEmpty = true);
 
+fs::path fileStem(const std::string &filename);
+
 //////////////
 
 

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -191,7 +191,7 @@ void Clip::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipel
 
             // for input file /x/y/z.las that goes to /tmp/hello.vpc,
             // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fs::path(f.filename).stem();
+            fs::path inputBasename = fileStem(f.filename);
             
             // if the output is not VPC  las file format is forced to avoid time spent on compression, files will be later merged into single output and removed anyways
             if (!ends_with(outputFile, ".vpc"))

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -99,6 +99,15 @@ static std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile)
         last.push_back(filterExpr);
     }
 
+    if (ends_with(tile->outputFilename, ".copc.laz"))
+    {
+        Stage *merge = &manager->makeFilter("filters.merge");
+        for (Stage *stage : last)
+            merge->setInput(*stage);
+        last.clear();
+        last.push_back(merge);
+    }
+
     pdal::Options options;
     options.add(pdal::Option("forward", "all"));
     Stage* writer = &manager->makeWriter(tile->outputFilename, "", options);

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -99,6 +99,9 @@ static std::unique_ptr<PipelineManager> pipeline(ParallelJobInfo *tile)
         last.push_back(filterExpr);
     }
 
+    // this is a special case for merging COPC files
+    // writers.copc does not support multiple inputs
+    //  merge step is necessary before writing the output
     if (ends_with(tile->outputFilename, ".copc.laz"))
     {
         Stage *merge = &manager->makeFilter("filters.merge");

--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -147,8 +147,10 @@ void Merge::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipe
 
             VirtualPointCloud vpc;
             if (!vpc.read(inputFile))
+            {
                 std::cerr << "could not open input VPC: " << inputFile << std::endl;
                 return;
+            }
             
             for (const VirtualPointCloud::File& vpcSingleFile : vpc.files)
             {

--- a/src/thin.cpp
+++ b/src/thin.cpp
@@ -167,7 +167,7 @@ void Thin::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipel
 
             // for input file /x/y/z.las that goes to /tmp/hello.vpc,
             // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fs::path(f.filename).stem();
+            fs::path inputBasename = fileStem(f.filename);
 
             if (!ends_with(outputFile, ".vpc"))
                 tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";

--- a/src/to_vector.cpp
+++ b/src/to_vector.cpp
@@ -112,7 +112,7 @@ void ToVector::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& p
 
             // for input file /x/y/z.las that goes to /tmp/hello.vpc,
             // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fs::path(f.filename).stem();
+            fs::path inputBasename = fileStem(f.filename);
             tile.outputFilename = (outputSubdir / inputBasename).string() + ".gpkg";
 
             tileOutputFiles.push_back(tile.outputFilename);

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -169,12 +169,12 @@ void Translate::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& 
 
             // for input file /x/y/z.las that goes to /tmp/hello.vpc,
             // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fs::path(f.filename).stem();
+            fs::path inputBasename = fileStem(f.filename);
 
             if (!ends_with(outputFile, ".vpc"))
                 tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
             else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + outputFormat;
+                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def _prepare_data():
 
     files_for_vpc = []
     files_for_vpc_copc = []
-    
+
     for i in range(1, 5):
 
         clip_gpkg_file = utils.test_data_filepath(f"rectangle{i}.gpkg")
@@ -181,13 +181,14 @@ def main_laz_file() -> str:
 
 
 @pytest.fixture
-def vpc_file() -> str:
-    "Return path to the vpc file"
+def vpc_laz_file() -> str:
+    "Return path to the vpc file referencing LAZ files"
     return utils.test_data_filepath("data.vpc").as_posix()
+
 
 @pytest.fixture
 def vpc_copc_file() -> str:
-    "Return path to the vpc file"
+    "Return path to the vpc file referencing COPC files"
     return utils.test_data_filepath("data_copc.vpc").as_posix()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,12 +33,16 @@ def _prepare_data():
     assert number_points == 693895
 
     files_for_vpc = []
+    files_for_vpc_copc = []
+    
     for i in range(1, 5):
 
         clip_gpkg_file = utils.test_data_filepath(f"rectangle{i}.gpkg")
         clipped_laz_file = utils.test_data_filepath(f"data_clipped{i}.laz")
+        clipped_copc_file = utils.test_data_filepath(f"data_clipped{i}.copc.laz")
 
         files_for_vpc.append(clipped_laz_file)
+        files_for_vpc_copc.append(clipped_copc_file)
 
         if not clipped_laz_file.exists():
 
@@ -67,6 +71,31 @@ def _prepare_data():
 
         assert clipped_laz_file.exists()
 
+        if not clipped_copc_file.exists():
+
+            input_file = base_data
+
+            res = subprocess.run(
+                [
+                    utils.pdal_wrench_path(),
+                    "clip",
+                    "--polygon",
+                    str(clip_gpkg_file),
+                    "--output",
+                    str(clipped_copc_file),
+                    "--input",
+                    str(input_file),
+                ],
+                check=True,
+            )
+
+            assert res.returncode == 0
+
+            clipped_copc = pdal.Reader(clipped_copc_file.as_posix()).pipeline()
+            number_points = clipped_copc.execute()
+
+            assert number_points > 0
+
     vpc_file = utils.test_data_filepath("data.vpc")
 
     if not vpc_file.exists():
@@ -87,6 +116,29 @@ def _prepare_data():
 
     vpc = pdal.Reader(vpc_file.as_posix()).pipeline()
     number_points = vpc.execute()
+
+    assert number_points == 338163
+
+    vpc_copc_file = utils.test_data_filepath("data_copc.vpc")
+
+    if not vpc_copc_file.exists():
+        res = subprocess.run(
+            [
+                utils.pdal_wrench_path(),
+                "build_vpc",
+                "--output",
+                vpc_copc_file.as_posix(),
+                *[f.as_posix() for f in files_for_vpc_copc],
+            ],
+            check=True,
+        )
+
+        assert res.returncode == 0
+
+    assert vpc_file.exists()
+
+    vpc_copc = pdal.Reader(vpc_copc_file.as_posix()).pipeline()
+    number_points = vpc_copc.execute()
 
     assert number_points == 338163
 
@@ -132,6 +184,11 @@ def main_laz_file() -> str:
 def vpc_file() -> str:
     "Return path to the vpc file"
     return utils.test_data_filepath("data.vpc").as_posix()
+
+@pytest.fixture
+def vpc_copc_file() -> str:
+    "Return path to the vpc file"
+    return utils.test_data_filepath("data_copc.vpc").as_posix()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,7 @@ def _prepare_data():
 
         assert res.returncode == 0
 
-    assert vpc_file.exists()
+    assert vpc_copc_file.exists()
 
     vpc_copc = pdal.Reader(vpc_copc_file.as_posix()).pipeline()
     number_points = vpc_copc.execute()

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -43,7 +43,7 @@ def test_boundary_copc(main_copc_file: str):
     assert output.exists()
 
 
-def test_boundary_on_vpc(vpc_file: str):
+def test_boundary_on_vpc(vpc_laz_file: str):
     """Test boundary on vpc function"""
 
     output = utils.test_data_filepath("boundary-vpc.gpkg")
@@ -53,7 +53,7 @@ def test_boundary_on_vpc(vpc_file: str):
             utils.pdal_wrench_path(),
             "boundary",
             f"--output={output.as_posix()}",
-            f"--input={vpc_file}",
+            f"--input={vpc_laz_file}",
         ],
         check=True,
     )

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -1,63 +1,31 @@
 import subprocess
+from pathlib import Path
 
+import pytest
 import utils
 
 
-def test_boundary_laz(main_laz_file: str):
+@pytest.mark.parametrize(
+    "input_path,output_path",
+    [
+        (utils.test_data_filepath("stadium-utm.laz"), utils.test_data_filepath("boundary-laz.gpkg")),
+        (utils.test_data_filepath("stadium-utm.copc.laz"), utils.test_data_filepath("boundary_copc.gpkg")),
+        (utils.test_data_filepath("data.vpc"), utils.test_data_filepath("boundary-vpc.gpkg")),
+    ],
+)
+def test_boundary(input_path: Path, output_path: Path):
     """Test boundary on las function"""
 
-    output = utils.test_data_filepath("boundary-laz.gpkg")
-
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "boundary",
-            f"--output={output.as_posix()}",
-            f"--input={main_laz_file}",
+            f"--output={output_path.as_posix()}",
+            f"--input={input_path.as_posix()}",
         ],
         check=True,
     )
 
     assert res.returncode == 0
 
-    assert output.exists()
-
-
-def test_boundary_copc(main_copc_file: str):
-    """Test boundary on copc function"""
-
-    output = utils.test_data_filepath("boundary_copc.gpkg")
-
-    res = subprocess.run(
-        [
-            utils.pdal_wrench_path(),
-            "boundary",
-            f"--output={output.as_posix()}",
-            f"--input={main_copc_file}",
-        ],
-        check=True,
-    )
-
-    assert res.returncode == 0
-
-    assert output.exists()
-
-
-def test_boundary_on_vpc(vpc_laz_file: str):
-    """Test boundary on vpc function"""
-
-    output = utils.test_data_filepath("boundary-vpc.gpkg")
-
-    res = subprocess.run(
-        [
-            utils.pdal_wrench_path(),
-            "boundary",
-            f"--output={output.as_posix()}",
-            f"--input={vpc_laz_file}",
-        ],
-        check=True,
-    )
-
-    assert res.returncode == 0
-
-    assert output.exists()
+    assert output_path.exists()

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -61,11 +61,11 @@ def test_input_file_output_file(
         ("vpc_copc_file", utils.test_data_filepath("clipped-vpc-copc-files.copc.laz")),
     ],
 )
-def test_clip_vpc(input_type: str, output: Path, vpc_file: str, vpc_copc_file: str):
+def test_clip_vpc(input_type: str, output: Path, vpc_laz_file: str, vpc_copc_file: str):
     """Test clip vpc to different outputs function"""
 
     if input_type == "vpc_file":
-        input = vpc_file
+        input = vpc_laz_file
     elif input_type == "vpc_copc_file":
         input = vpc_copc_file
     else:

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,42 +1,32 @@
 import subprocess
 from pathlib import Path
 
-import numpy as np
 import pdal
 import pytest
 import utils
 
 
 @pytest.mark.parametrize(
-    "input_type,output",
+    "input_path,output_path",
     [
-        ("main_laz", utils.test_data_filepath("clipped.las")),
-        ("main_laz", utils.test_data_filepath("clipped.copc.laz")),
-        ("main_copc", utils.test_data_filepath("clipped-copc-input.laz")),
-        ("main_copc", utils.test_data_filepath("clipped-copc-input.copc.laz")),
+        (utils.test_data_filepath("stadium-utm.laz"), utils.test_data_filepath("clipped.las")),
+        (utils.test_data_filepath("stadium-utm.laz"), utils.test_data_filepath("clipped.copc.laz")),
+        (utils.test_data_filepath("stadium-utm.copc.laz"), utils.test_data_filepath("clipped-copc-input.laz")),
+        (utils.test_data_filepath("stadium-utm.copc.laz"), utils.test_data_filepath("clipped-copc-input.copc.laz")),
     ],
 )
 def test_input_file_output_file(
-    input_type: str,
-    output: Path,
-    main_laz_file: str,
-    main_copc_file: str,
+    input_path: Path,
+    output_path: Path,
 ):
     """Test clip input is file output is file"""
-
-    if input_type == "main_laz":
-        input = main_laz_file
-    elif input_type == "main_copc":
-        input = main_copc_file
-    else:
-        assert False, "Invalid input type"
 
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "clip",
-            f"--output={output.as_posix()}",
-            f"--input={input}",
+            f"--output={output_path.as_posix()}",
+            f"--input={input_path.as_posix()}",
             f"--polygon={utils.test_data_filepath('rectangle1.gpkg')}",
         ],
         check=True,
@@ -44,9 +34,9 @@ def test_input_file_output_file(
 
     assert res.returncode == 0
 
-    assert output.exists()
+    assert output_path.exists()
 
-    pipeline = pdal.Reader(filename=output.as_posix()).pipeline()
+    pipeline = pdal.Reader(filename=output_path.as_posix()).pipeline()
 
     number_of_points = pipeline.execute()
 
@@ -54,29 +44,25 @@ def test_input_file_output_file(
 
 
 @pytest.mark.parametrize(
-    "input_type,output",
+    "input_path,output_path",
     [
-        ("vpc_file", utils.test_data_filepath("clipped-vpc.copc.laz")),
-        ("vpc_copc_file", utils.test_data_filepath("clipped-vpc-copc-files.vpc")),
-        ("vpc_copc_file", utils.test_data_filepath("clipped-vpc-copc-files.copc.laz")),
+        (utils.test_data_filepath("data.vpc"), utils.test_data_filepath("clipped-vpc.copc.laz")),
+        (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("clipped-vpc-copc-files.vpc")),
+        (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("clipped-vpc-copc-files.copc.laz")),
     ],
 )
-def test_clip_vpc(input_type: str, output: Path, vpc_laz_file: str, vpc_copc_file: str):
+def test_clip_vpc(
+    input_path: Path,
+    output_path: Path,
+):
     """Test clip vpc to different outputs function"""
-
-    if input_type == "vpc_file":
-        input = vpc_laz_file
-    elif input_type == "vpc_copc_file":
-        input = vpc_copc_file
-    else:
-        assert False, "Invalid input type"
 
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "clip",
-            f"--output={output.as_posix()}",
-            f"--input={input}",
+            f"--output={output_path.as_posix()}",
+            f"--input={input_path.as_posix()}",
             f"--polygon={utils.test_data_filepath('rectangle.gpkg')}",
         ],
         check=True,
@@ -84,9 +70,9 @@ def test_clip_vpc(input_type: str, output: Path, vpc_laz_file: str, vpc_copc_fil
 
     assert res.returncode == 0
 
-    assert output.exists()
+    assert output_path.exists()
 
-    pipeline = pdal.Reader(filename=output.as_posix()).pipeline()
+    pipeline = pdal.Reader(filename=output_path.as_posix()).pipeline()
 
     number_of_points = pipeline.execute()
 

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,21 +1,42 @@
 import subprocess
+from pathlib import Path
 
 import numpy as np
 import pdal
+import pytest
 import utils
 
 
-def test_clip_laz_to_las(main_laz_file: str):
-    """Test clip las function"""
+@pytest.mark.parametrize(
+    "input_type,output",
+    [
+        ("main_laz", utils.test_data_filepath("clipped.las")),
+        ("main_laz", utils.test_data_filepath("clipped.copc.laz")),
+        ("main_copc", utils.test_data_filepath("clipped-copc-input.laz")),
+        ("main_copc", utils.test_data_filepath("clipped-copc-input.copc.laz")),
+    ],
+)
+def test_input_file_output_file(
+    input_type: str,
+    output: Path,
+    main_laz_file: str,
+    main_copc_file: str,
+):
+    """Test clip input is file output is file"""
 
-    clipped_las_file = utils.test_data_filepath("clipped.las")
+    if input_type == "main_laz":
+        input = main_laz_file
+    elif input_type == "main_copc":
+        input = main_copc_file
+    else:
+        assert False, "Invalid input type"
 
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "clip",
-            f"--output={clipped_las_file.as_posix()}",
-            f"--input={main_laz_file}",
+            f"--output={output.as_posix()}",
+            f"--input={input}",
             f"--polygon={utils.test_data_filepath('rectangle1.gpkg')}",
         ],
         check=True,
@@ -23,67 +44,39 @@ def test_clip_laz_to_las(main_laz_file: str):
 
     assert res.returncode == 0
 
-    assert clipped_las_file.exists()
+    assert output.exists()
 
-    pipeline = pdal.Reader.las(filename=clipped_las_file.as_posix()).pipeline()
-
-    number_of_points = pipeline.execute()
-
-    assert number_of_points == 66832
-
-    # points as numpy array
-    array = pipeline.arrays[0]
-
-    # all points
-    assert isinstance(array, np.ndarray)
-
-    # first point
-    assert isinstance(array[0], np.void)
-    assert len(array[0]) == 20
-    assert isinstance(array[0]["X"], np.float64)
-    assert isinstance(array[0]["Y"], np.float64)
-    assert isinstance(array[0]["Z"], np.float64)
-    assert isinstance(array[0]["Intensity"], np.uint16)
-
-
-def test_clip_laz_to_copc(main_laz_file: str):
-    """Test clip las function"""
-
-    clipped_las_file = utils.test_data_filepath("clipped.copc.laz")
-
-    res = subprocess.run(
-        [
-            utils.pdal_wrench_path(),
-            "clip",
-            f"--output={clipped_las_file.as_posix()}",
-            f"--input={main_laz_file}",
-            f"--polygon={utils.test_data_filepath('rectangle1.gpkg')}",
-        ],
-        check=True,
-    )
-
-    assert res.returncode == 0
-
-    assert clipped_las_file.exists()
-
-    pipeline = pdal.Reader.las(filename=clipped_las_file.as_posix()).pipeline()
+    pipeline = pdal.Reader(filename=output.as_posix()).pipeline()
 
     number_of_points = pipeline.execute()
 
     assert number_of_points == 66832
 
 
-def test_clip_vpc_to_copc(vpc_file: str):
-    """Test clip vpc to copc function"""
+@pytest.mark.parametrize(
+    "input_type,output",
+    [
+        ("vpc_file", utils.test_data_filepath("clipped-vpc.copc.laz")),
+        ("vpc_copc_file", utils.test_data_filepath("clipped-vpc-copc-files.vpc")),
+        ("vpc_copc_file", utils.test_data_filepath("clipped-vpc-copc-files.copc.laz")),
+    ],
+)
+def test_clip_vpc(input_type: str, output: Path, vpc_file: str, vpc_copc_file: str):
+    """Test clip vpc to different outputs function"""
 
-    clipped_file = utils.test_data_filepath("clipped-vpc.copc.laz")
+    if input_type == "vpc_file":
+        input = vpc_file
+    elif input_type == "vpc_copc_file":
+        input = vpc_copc_file
+    else:
+        assert False, "Invalid input type"
 
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "clip",
-            f"--output={clipped_file.as_posix()}",
-            f"--input={vpc_file}",
+            f"--output={output.as_posix()}",
+            f"--input={input}",
             f"--polygon={utils.test_data_filepath('rectangle.gpkg')}",
         ],
         check=True,
@@ -91,37 +84,10 @@ def test_clip_vpc_to_copc(vpc_file: str):
 
     assert res.returncode == 0
 
-    assert clipped_file.exists()
+    assert output.exists()
 
-    pipeline = pdal.Reader.copc(filename=clipped_file.as_posix()).pipeline()
-
-    number_of_points = pipeline.execute()
-
-    assert number_of_points == 19983
-
-
-def test_clip_copc_to_laz(main_copc_file: str):
-    """Test clip las function"""
-
-    clipped_laz_file = utils.test_data_filepath("clipped-copc-input.laz")
-
-    res = subprocess.run(
-        [
-            utils.pdal_wrench_path(),
-            "clip",
-            f"--output={clipped_laz_file.as_posix()}",
-            f"--input={main_copc_file}",
-            f"--polygon={utils.test_data_filepath('rectangle1.gpkg')}",
-        ],
-        check=True,
-    )
-
-    assert res.returncode == 0
-
-    assert clipped_laz_file.exists()
-
-    pipeline = pdal.Reader(filename=clipped_laz_file.as_posix()).pipeline()
+    pipeline = pdal.Reader(filename=output.as_posix()).pipeline()
 
     number_of_points = pipeline.execute()
 
-    assert number_of_points == 66832
+    assert number_of_points == 66911

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -8,25 +8,20 @@ import utils
 
 
 @pytest.mark.parametrize(
-    "input_type,output",
+    "output_path",
     [
-        ("laz_files", utils.test_data_filepath("data_merged.las")),
-        ("laz_files", utils.test_data_filepath("data_merged.copc.laz")),
+        (utils.test_data_filepath("data_merged.las")),
+        (utils.test_data_filepath("data_merged.copc.laz")),
     ],
 )
-def test_merge_to_file(input_type: str, output: Path, laz_files: typing.List[str]):
+def test_merge_to_file(output_path: Path, laz_files: typing.List[str]):
     """Test merge las function"""
-
-    if input_type == "laz_files":
-        input_files = laz_files
-    else:
-        assert False, "Invalid input type"
 
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "merge",
-            f"--output={output.as_posix()}",
+            f"--output={output_path.as_posix()}",
             *laz_files,
         ],
         check=True,
@@ -34,7 +29,7 @@ def test_merge_to_file(input_type: str, output: Path, laz_files: typing.List[str
 
     assert res.returncode == 0
 
-    pipeline = pdal.Reader(filename=output.as_posix()).pipeline()
+    pipeline = pdal.Reader(filename=output_path.as_posix()).pipeline()
 
     number_of_points = pipeline.execute()
 
@@ -42,43 +37,33 @@ def test_merge_to_file(input_type: str, output: Path, laz_files: typing.List[str
 
 
 @pytest.mark.parametrize(
-    "input_type,output",
+    "input_path,output_path",
     [
-        ("vpc_copc_file", utils.test_data_filepath("merged-copc-vpc.las")),
-        ("vpc_copc_file", utils.test_data_filepath("merged-copc-vpc.cop.laz")),
-        ("vpc_file", utils.test_data_filepath("merged-vpc.copc.laz")),
-        ("vpc_file", utils.test_data_filepath("merged-vpc.las")),
+        (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("merged-copc-vpc.las")),
+        (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("merged-copc-vpc.cop.laz")),
+        (utils.test_data_filepath("data.vpc"), utils.test_data_filepath("merged-vpc.copc.laz")),
+        (utils.test_data_filepath("data.vpc"), utils.test_data_filepath("merged-vpc.las")),
     ],
 )
 def test_merge_vpc(
-    input_type: str,
-    output: Path,
-    vpc_laz_file: str,
-    vpc_copc_file: str,
+    input_path: Path,
+    output_path: Path,
 ):
     """Test merge of vpc file"""
 
-    if input_type == "vpc_file":
-        input = vpc_laz_file
-    elif input_type == "vpc_copc_file":
-        input = vpc_copc_file
-    else:
-        assert False, "Invalid input type"
-
-    print(f" {utils.pdal_wrench_path()}" " merge" f" --output={output.as_posix()}" f" {input}")
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "merge",
-            f"--output={output.as_posix()}",
-            input,
+            f"--output={output_path.as_posix()}",
+            input_path.as_posix(),
         ],
         check=True,
     )
 
     assert res.returncode == 0
 
-    pipeline = pdal.Reader(filename=output.as_posix()).pipeline()
+    pipeline = pdal.Reader(filename=output_path.as_posix()).pipeline()
 
     number_of_points = pipeline.execute()
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -53,13 +53,13 @@ def test_merge_to_file(input_type: str, output: Path, laz_files: typing.List[str
 def test_merge_vpc(
     input_type: str,
     output: Path,
-    vpc_file: str,
+    vpc_laz_file: str,
     vpc_copc_file: str,
 ):
     """Test merge of vpc file"""
 
     if input_type == "vpc_file":
-        input = vpc_file
+        input = vpc_laz_file
     elif input_type == "vpc_copc_file":
         input = vpc_copc_file
     else:

--- a/tests/test_thin.py
+++ b/tests/test_thin.py
@@ -1,117 +1,41 @@
 import subprocess
-import typing
+from pathlib import Path
 
 import pdal
+import pytest
 import utils
 
 
-def test_thin_laz_to_las(main_laz_file: str):
+@pytest.mark.parametrize(
+    "input_path,output_path,point_count",
+    [
+        (utils.test_data_filepath("stadium-utm.laz"), utils.test_data_filepath("thin.las"), 138779),
+        (utils.test_data_filepath("stadium-utm.laz"), utils.test_data_filepath("thin.copc.laz"), 138779),
+        (utils.test_data_filepath("stadium-utm.copc.laz"), utils.test_data_filepath("thin-copc-input.laz"), 138779),
+        (utils.test_data_filepath("data.vpc"), utils.test_data_filepath("thin-vpc.copc.laz"), 67634),
+    ],
+)
+def test_thin(input_path: Path, output_path: Path, point_count: int):
     """Test thin to las function"""
 
-    output = utils.test_data_filepath("thin.las")
-
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "thin",
             "--mode=every-nth",
             "--step-every-nth=5",
-            f"--input={main_laz_file}",
-            f"--output={output.as_posix()}",
+            f"--input={input_path.as_posix()}",
+            f"--output={output_path.as_posix()}",
         ],
         check=True,
     )
 
     assert res.returncode == 0
 
-    assert output.exists()
+    assert output_path.exists()
 
-    pipeline = pdal.Reader.las(filename=output.as_posix()).pipeline()
-
-    number_of_points = pipeline.execute()
-
-    assert number_of_points == 138779
-
-
-def test_thin_laz_to_copc(main_laz_file: str):
-    """Test thin to copc function"""
-
-    output = utils.test_data_filepath("thin.copc.laz")
-
-    res = subprocess.run(
-        [
-            utils.pdal_wrench_path(),
-            "thin",
-            "--mode=every-nth",
-            "--step-every-nth=5",
-            f"--input={main_laz_file}",
-            f"--output={output.as_posix()}",
-        ],
-        check=True,
-    )
-
-    assert res.returncode == 0
-
-    assert output.exists()
-
-    pipeline = pdal.Reader.copc(filename=output.as_posix()).pipeline()
+    pipeline = pdal.Reader(filename=output_path.as_posix()).pipeline()
 
     number_of_points = pipeline.execute()
 
-    assert number_of_points == 138779
-
-
-def test_thin_vpc_to_copc(vpc_laz_file: str):
-    """Test thin vpc to copc function"""
-
-    output = utils.test_data_filepath("thin-vpc.copc.laz")
-
-    res = subprocess.run(
-        [
-            utils.pdal_wrench_path(),
-            "thin",
-            "--mode=every-nth",
-            "--step-every-nth=5",
-            f"--input={vpc_laz_file}",
-            f"--output={output.as_posix()}",
-        ],
-        check=True,
-    )
-
-    assert res.returncode == 0
-
-    assert output.exists()
-
-    pipeline = pdal.Reader.copc(filename=output.as_posix()).pipeline()
-
-    number_of_points = pipeline.execute()
-
-    assert number_of_points == 67634
-
-
-def test_thin_copc_to_laz(main_copc_file: str):
-    """Test thin copc to laz function"""
-
-    output = utils.test_data_filepath("thin-copc-input.laz")
-
-    res = subprocess.run(
-        [
-            utils.pdal_wrench_path(),
-            "thin",
-            "--mode=every-nth",
-            "--step-every-nth=5",
-            f"--input={main_copc_file}",
-            f"--output={output.as_posix()}",
-        ],
-        check=True,
-    )
-
-    assert res.returncode == 0
-
-    assert output.exists()
-
-    pipeline = pdal.Reader(filename=output.as_posix()).pipeline()
-
-    number_of_points = pipeline.execute()
-
-    assert number_of_points == 138779
+    assert number_of_points == point_count

--- a/tests/test_thin.py
+++ b/tests/test_thin.py
@@ -61,7 +61,7 @@ def test_thin_laz_to_copc(main_laz_file: str):
     assert number_of_points == 138779
 
 
-def test_thin_vpc_to_copc(vpc_file: str):
+def test_thin_vpc_to_copc(vpc_laz_file: str):
     """Test thin vpc to copc function"""
 
     output = utils.test_data_filepath("thin-vpc.copc.laz")
@@ -72,7 +72,7 @@ def test_thin_vpc_to_copc(vpc_file: str):
             "thin",
             "--mode=every-nth",
             "--step-every-nth=5",
-            f"--input={vpc_file}",
+            f"--input={vpc_laz_file}",
             f"--output={output.as_posix()}",
         ],
         check=True,

--- a/tests/test_thin.py
+++ b/tests/test_thin.py
@@ -86,7 +86,7 @@ def test_thin_vpc_to_copc(vpc_file: str):
 
     number_of_points = pipeline.execute()
 
-    assert number_of_points == 19593
+    assert number_of_points == 67634
 
 
 def test_thin_copc_to_laz(main_copc_file: str):

--- a/tests/test_to_vector.py
+++ b/tests/test_to_vector.py
@@ -39,7 +39,7 @@ def test_to_vector_las_file(main_laz_file: str):
     assert layer.GetFeatureCount() == 693895
 
 
-def test_to_vector_vpc_file(vpc_file: str):
+def test_to_vector_vpc_file(vpc_laz_file: str):
     """Test to_vector las function"""
 
     gpkg_file = utils.test_data_filepath("points.gpkg")
@@ -51,7 +51,7 @@ def test_to_vector_vpc_file(vpc_file: str):
             utils.pdal_wrench_path(),
             "to_vector",
             f"--output={gpkg_file.as_posix()}",
-            f"--input={vpc_file}",
+            f"--input={vpc_laz_file}",
         ],
         check=True,
     )

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -22,7 +22,7 @@ def test_translate_files(
     point_count: int,
     main_laz_file: str,
     main_copc_file: str,
-    vpc_file: str,
+    vpc_laz_file: str,
     vpc_copc_file: str,
 ):
     """Test translate las function"""
@@ -32,7 +32,7 @@ def test_translate_files(
     elif input_type == "main_copc":
         input = main_copc_file
     elif input_type == "vpc_file":
-        input = vpc_file
+        input = vpc_laz_file
     elif input_type == "vpc_copc_file":
         input = vpc_copc_file
     else:

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -7,53 +7,34 @@ import utils
 
 
 @pytest.mark.parametrize(
-    "input_type,output,point_count",
+    "input_path,output_path,point_count",
     [
-        ("main_laz", utils.test_data_filepath("translate.las"), 693895),
-        ("main_laz", utils.test_data_filepath("translate.copc.laz"), 693895),
-        ("main_copc", utils.test_data_filepath("translate-copc-input.laz"), 693895),
-        ("vpc_file", utils.test_data_filepath("translate-vpc.copc.laz"), 338163),
-        ("vpc_copc_file", utils.test_data_filepath("translate.vpc"), 338163),
+        (utils.test_data_filepath("stadium-utm.laz"), utils.test_data_filepath("translate.las"), 693895),
+        (utils.test_data_filepath("stadium-utm.laz"), utils.test_data_filepath("translate.copc.laz"), 693895),
+        (utils.test_data_filepath("stadium-utm.copc.laz"), 693895),
+        (utils.test_data_filepath("data.vpc"), utils.test_data_filepath("translate-vpc.copc.laz"), 338163),
+        (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("translate.vpc"), 338163),
     ],
 )
-def test_translate_files(
-    input_type: str,
-    output: Path,
-    point_count: int,
-    main_laz_file: str,
-    main_copc_file: str,
-    vpc_laz_file: str,
-    vpc_copc_file: str,
-):
+def test_translate_files(input_path: Path, output_path: Path, point_count: int):
     """Test translate las function"""
 
-    if input_type == "main_laz":
-        input = main_laz_file
-    elif input_type == "main_copc":
-        input = main_copc_file
-    elif input_type == "vpc_file":
-        input = vpc_laz_file
-    elif input_type == "vpc_copc_file":
-        input = vpc_copc_file
-    else:
-        assert False, "Invalid input type"
-
-    print(f"{utils.pdal_wrench_path()} translate --input={input} --output={output.as_posix()}")
+    print(f"{utils.pdal_wrench_path()} translate --input={input_path} --output={output_path.as_posix()}")
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "translate",
-            f"--input={input}",
-            f"--output={output.as_posix()}",
+            f"--input={input_path.as_posix()}",
+            f"--output={output_path.as_posix()}",
         ],
         check=True,
     )
 
     assert res.returncode == 0
 
-    assert output.exists()
+    assert output_path.exists()
 
-    pipeline = pdal.Reader(filename=output.as_posix()).pipeline()
+    pipeline = pdal.Reader(filename=output_path.as_posix()).pipeline()
 
     number_of_points = pipeline.execute()
 

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -17,7 +17,7 @@ import utils
     ],
 )
 def test_translate_files(input_path: Path, output_path: Path, point_count: int):
-    """Test translate las function"""
+    """Test translate function"""
 
     print(f"{utils.pdal_wrench_path()} translate --input={input_path} --output={output_path.as_posix()}")
     res = subprocess.run(

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -11,7 +11,11 @@ import utils
     [
         (utils.test_data_filepath("stadium-utm.laz"), utils.test_data_filepath("translate.las"), 693895),
         (utils.test_data_filepath("stadium-utm.laz"), utils.test_data_filepath("translate.copc.laz"), 693895),
-        (utils.test_data_filepath("stadium-utm.copc.laz"), 693895),
+        (
+            utils.test_data_filepath("stadium-utm.copc.laz"),
+            utils.test_data_filepath("translate-copc-input.copc.laz"),
+            693895,
+        ),
         (utils.test_data_filepath("data.vpc"), utils.test_data_filepath("translate-vpc.copc.laz"), 338163),
         (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("translate.vpc"), 338163),
     ],

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -16,7 +16,7 @@ import utils
         ("vpc_copc_file", utils.test_data_filepath("translate.vpc"), 338163),
     ],
 )
-def test_translate_laz_to_las(
+def test_translate_files(
     input_type: str,
     output: Path,
     point_count: int,

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,98 +1,49 @@
 import subprocess
-import typing
+from pathlib import Path
 
 import pdal
+import pytest
 import utils
 
 
-def test_translate_laz_to_las(main_laz_file: str):
+@pytest.mark.parametrize(
+    "input_type,output,point_count",
+    [
+        ("main_laz", utils.test_data_filepath("translate.las"), 693895),
+        ("main_laz", utils.test_data_filepath("translate.copc.laz"), 693895),
+        ("main_copc", utils.test_data_filepath("translate-copc-input.laz"), 693895),
+        ("vpc_file", utils.test_data_filepath("translate-vpc.copc.laz"), 338163),
+        ("vpc_copc_file", utils.test_data_filepath("translate.vpc"), 338163),
+    ],
+)
+def test_translate_laz_to_las(
+    input_type: str,
+    output: Path,
+    point_count: int,
+    main_laz_file: str,
+    main_copc_file: str,
+    vpc_file: str,
+    vpc_copc_file: str,
+):
     """Test translate las function"""
 
-    output = utils.test_data_filepath("translate.las")
+    if input_type == "main_laz":
+        input = main_laz_file
+    elif input_type == "main_copc":
+        input = main_copc_file
+    elif input_type == "vpc_file":
+        input = vpc_file
+    elif input_type == "vpc_copc_file":
+        input = vpc_copc_file
+    else:
+        assert False, "Invalid input type"
 
+    print(f"{utils.pdal_wrench_path()} translate --input={input} --output={output.as_posix()}")
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "translate",
-            f"--input={main_laz_file}",
-            f"--output={output.as_posix()}",
-        ],
-        check=True,
-    )
-
-    assert res.returncode == 0
-
-    assert output.exists()
-
-    pipeline = pdal.Reader.las(filename=output.as_posix()).pipeline()
-
-    number_of_points = pipeline.execute()
-
-    assert number_of_points == 693895
-
-
-def test_translate_laz_to_copc(main_laz_file: str):
-    """Test translate las function"""
-
-    output = utils.test_data_filepath("translate.copc.laz")
-
-    res = subprocess.run(
-        [
-            utils.pdal_wrench_path(),
-            "translate",
-            f"--input={main_laz_file}",
-            f"--output={output.as_posix()}",
-        ],
-        check=True,
-    )
-
-    assert res.returncode == 0
-
-    assert output.exists()
-
-    pipeline = pdal.Reader.copc(filename=output.as_posix()).pipeline()
-
-    number_of_points = pipeline.execute()
-
-    assert number_of_points == 693895
-
-
-def test_translate_vpc_to_copc(vpc_file: str):
-    """Test translate vpc to copc function"""
-
-    output = utils.test_data_filepath("translate-vpc.copc.laz")
-
-    res = subprocess.run(
-        [
-            utils.pdal_wrench_path(),
-            "translate",
-            f"--input={vpc_file}",
-            f"--output={output.as_posix()}",
-        ],
-        check=True,
-    )
-
-    assert res.returncode == 0
-
-    assert output.exists()
-
-    pipeline = pdal.Reader.copc(filename=output.as_posix()).pipeline()
-
-    number_of_points = pipeline.execute()
-
-    assert number_of_points == 97965
-
-
-def test_translate_copc_to_laz(main_copc_file: str):
-    """Test translate copc to copc function"""
-
-    output = utils.test_data_filepath("translate-copc-input.laz")
-
-    res = subprocess.run(
-        [
-            utils.pdal_wrench_path(),
-            "translate",
-            f"--input={main_copc_file}",
+            f"--input={input}",
             f"--output={output.as_posix()}",
         ],
         check=True,
@@ -106,4 +57,4 @@ def test_translate_copc_to_laz(main_copc_file: str):
 
     number_of_points = pipeline.execute()
 
-    assert number_of_points == 693895
+    assert number_of_points == point_count


### PR DESCRIPTION
Fixes several slight related issues:

- main issue was in merge which did not run if the output was **copc.laz** that also caused issue in other tools as some of them use Merge as last step
-  for **VPC** there as an issue if the files in **VPC** were **.copc.laz** where the extensions were not stripped correctly for this the  `fs::path fileStem(const std::string &filename)` was introduced which should only return stem of file without any extensions
- tests that looked really similary were parametrized and some test cases were added (mostly with input with **VPC** containing **.copc.laz** files and output of algs to **.copc.laz**)

Fixes qgis/QGIS#62415 and possibly similar issues
