### PR TITLE
Do not crash if input file is unreachable

### DIFF
--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -496,7 +496,17 @@ void buildVpc(std::vector<std::string> args)
         }
 
         MetadataNode layout;
-        MetadataNode n = getReaderMetadata(inputFileAbsolute, &layout);
+        MetadataNode n;
+        try
+        {
+            n = getReaderMetadata(inputFileAbsolute, &layout);
+        }
+        catch (std::exception &e)
+        {
+            std::cerr << e.what() << std::endl;
+            return;
+        }
+
         point_count_t cnt = n.findChild("count").value<point_count_t>();
         BOX3D bbox(
                 n.findChild("minx").value<double>(),


### PR DESCRIPTION
Both reading local and remote copc file header can throw.
This will also give some feedback to the caller about what went wrong.
```
Unable to open '/tmp/42.copc.laz'. File does not exist.
```
```
Could not read from pdal.io/42.copc.laz
```
Cases like https://github.com/qgis/QGIS/issues/59802 will be easier to diagnose.