### PR TITLE
Vpc format update

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ This will create a grid for each data file separately in parallel and then merge
 pdal_wrench density --input=hello.vpc --resolution=1 --output=density.tif
 ```
 
-When algorithms create derived VPCs, by default they use uncompressed LAS, but `--output-format=laz` option can switch to compressed LAZ.
+When algorithms create derived VPCs, by default they use COPC, but argument `--vpc-output-format=las` can be used to switch to LAS, LAZ or COPC.
 
 ## VPC support in algorithms
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ This will create a grid for each data file separately in parallel and then merge
 pdal_wrench density --input=hello.vpc --resolution=1 --output=density.tif
 ```
 
-When algorithms create derived VPCs, by default they use COPC, but argument `--vpc-output-format=las` can be used to switch to LAS, LAZ or COPC.
+When algorithms create derived VPCs, by default they use COPC, but argument `--vpc-output-format=las` (allowed values are `las`, `laz`, `copc`) can be used to switch to LAS, LAZ or COPC. COPC format is preferred so that tools like QGIS can immediately view the data, the conversion to COPC format takes time so the operation will be slower. If multiple operations are to be run one after the other, it may be better to use LAS or LAZ format for intermediate VPCs for faster processing.
 
 ## VPC support in algorithms
 

--- a/src/alg.hpp
+++ b/src/alg.hpp
@@ -116,12 +116,12 @@ struct Translate : public Alg
     std::string assignCrs;
     std::string transformCrs;
     std::string transformCoordOp;
-    std::string outputFormat;  // las / laz / copc
+    std::string outputFormatVpc;  // las / laz / copc
     std::string transformMatrix; // 4x4 matrix as 16 space-separated values
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
 
     std::vector<std::string> tileOutputFiles;
 
@@ -187,11 +187,11 @@ struct Clip : public Alg
     // parameters from the user
     std::string outputFile;
     std::string polygonFile;
-    std::string outputFormat;  // las / laz / copc
+    std::string outputFormatVpc;  // las / laz / copc
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
     pdal::Arg* argPolygon = nullptr;
 
     std::vector<std::string> tileOutputFiles;
@@ -235,14 +235,14 @@ struct Thin : public Alg
     std::string mode;  // "every-nth" or "sample"
     int stepEveryN;  // keep every N-th point
     double stepSample;  // cell size for Poisson sampling
-    std::string outputFormat;  // las / laz / copc
+    std::string outputFormatVpc;  // las / laz / copc
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
     pdal::Arg* argMode = nullptr;
     pdal::Arg* argStepEveryN = nullptr;
     pdal::Arg* argStepSample = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
 
     std::vector<std::string> tileOutputFiles;
 
@@ -342,7 +342,7 @@ struct ClassifyGround : public Alg
 
     // parameters from the user
     std::string outputFile;
-    std::string outputFormat;  // las / laz / copc
+    std::string outputFormatVpc;  // las / laz / copc
 
     double cellSize = 1.0;
     double scalar = 1.25;
@@ -352,7 +352,7 @@ struct ClassifyGround : public Alg
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
     pdal::Arg* argCellSize = nullptr;
 
     pdal::Arg* argScalar = nullptr;
@@ -379,7 +379,7 @@ struct FilterNoise: public Alg
     
     // parameters from the user
     std::string outputFile;
-    std::string outputFormat;  // las / laz / copc
+    std::string outputFormatVpc;  // las / laz / copc
     std::string algorithm = "statistical"; // "statistical" or "radius"
     bool removeNoisePoints = false;
 
@@ -393,7 +393,7 @@ struct FilterNoise: public Alg
 
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
     pdal::Arg* argAlgorithm = nullptr;
     pdal::Arg* argRemoveNoisePoints = nullptr;
     pdal::Arg* argRadiusMinK = nullptr;
@@ -415,7 +415,7 @@ struct HeightAboveGround : public Alg
     
     // parameters from the user
     std::string outputFile;
-    std::string outputFormat;  // las / laz / copc / vpc
+    std::string outputFormatVpc;  // las / laz / copc
     bool replaceZWithHeightAboveGround = true;
     std::string algorithm = "nn";
 
@@ -428,7 +428,7 @@ struct HeightAboveGround : public Alg
     
     // args - initialized in addArgs()
     pdal::Arg* argOutput = nullptr;
-    pdal::Arg* argOutputFormat = nullptr;
+    pdal::Arg* argOutputFormatVpc = nullptr;
     pdal::Arg* argReplaceZWithHeightAboveGround = nullptr;
     pdal::Arg* argAlgorithm = nullptr;
 

--- a/src/classify_ground.cpp
+++ b/src/classify_ground.cpp
@@ -35,7 +35,7 @@ namespace fs = std::filesystem;
 void ClassifyGround::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc, "copc");
     
     argCellSize = &programArgs.add("cell-size", "Sets the grid cell size in map units. Smaller values give finer detail but may increase noise.", cellSize, 1.0);
     argScalar = &programArgs.add("scalar", "Increases the threshold on steeper slopes. Raise this for rough terrain.", scalar, 1.25);
@@ -60,9 +60,7 @@ bool ClassifyGround::checkArgs()
             return false;
         }
     }
-    else
-        outputFormatVpc = "las";  // uncompressed by default
-
+    
     return true;
 }
 

--- a/src/classify_ground.cpp
+++ b/src/classify_ground.cpp
@@ -35,7 +35,7 @@ namespace fs = std::filesystem;
 void ClassifyGround::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormat = &programArgs.add("output-format", "Output format (las/laz/copc)", outputFormat);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc);
     
     argCellSize = &programArgs.add("cell-size", "Sets the grid cell size in map units. Smaller values give finer detail but may increase noise.", cellSize, 1.0);
     argScalar = &programArgs.add("scalar", "Increases the threshold on steeper slopes. Raise this for rough terrain.", scalar, 1.25);
@@ -52,16 +52,16 @@ bool ClassifyGround::checkArgs()
         return false;
     }
 
-    if (argOutputFormat->set())
+    if (argOutputFormatVpc->set())
     {
-        if (outputFormat != "las" && outputFormat != "laz" && outputFormat != "copc")
+        if (outputFormatVpc != "las" && outputFormatVpc != "laz" && outputFormatVpc != "copc")
         {
-            std::cerr << "unknown output format: " << outputFormat << std::endl;
+            std::cerr << "unknown output format: " << outputFormatVpc << std::endl;
             return false;
         }
     }
     else
-        outputFormat = "las";  // uncompressed by default
+        outputFormatVpc = "las";  // uncompressed by default
 
     return true;
 }
@@ -134,14 +134,7 @@ void ClassifyGround::preparePipelines(std::vector<std::unique_ptr<PipelineManage
             ParallelJobInfo tile(ParallelJobInfo::FileBased, BOX2D(), filterExpression, filterBounds);
             tile.inputFilenames.push_back(f.filename);
 
-            // for input file /x/y/z.las that goes to /tmp/hello.vpc,
-            // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fileStem(f.filename);
-
-            if (!ends_with(outputFile, ".vpc"))
-                tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
-            else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
+            tile.outputFilename = tileOutputFileName(outputFile, outputFormatVpc, outputSubdir, f.filename);
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/src/classify_ground.cpp
+++ b/src/classify_ground.cpp
@@ -61,6 +61,11 @@ bool ClassifyGround::checkArgs()
         }
     }
     
+    if ( ends_with(outputFile, ".vpc") && outputFormatVpc == "copc" )
+    {
+        isStreaming = false;
+    }
+    
     return true;
 }
 

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -34,7 +34,7 @@ namespace fs = std::filesystem;
 void Clip::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc, "copc");
     argPolygon = &programArgs.add("polygon,p", "Input polygon vector file", polygonFile);
 }
 
@@ -59,8 +59,6 @@ bool Clip::checkArgs()
             return false;
         }
     }
-    else
-        outputFormatVpc = "las";  // uncompressed by default
 
     return true;
 }

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -60,6 +60,11 @@ bool Clip::checkArgs()
         }
     }
 
+    if ( ends_with(outputFile, ".vpc") && outputFormatVpc == "copc" )
+    {
+        isStreaming = false;
+    }
+    
     return true;
 }
 

--- a/src/clip.cpp
+++ b/src/clip.cpp
@@ -34,7 +34,7 @@ namespace fs = std::filesystem;
 void Clip::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormat = &programArgs.add("output-format", "Output format (las/laz/copc)", outputFormat);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc);
     argPolygon = &programArgs.add("polygon,p", "Input polygon vector file", polygonFile);
 }
 
@@ -51,16 +51,16 @@ bool Clip::checkArgs()
         return false;
     }
 
-    if (argOutputFormat->set())
+    if (argOutputFormatVpc->set())
     {
-        if (outputFormat != "las" && outputFormat != "laz")
+        if (outputFormatVpc != "las" && outputFormatVpc != "laz" && outputFormatVpc != "copc")
         {
-            std::cerr << "unknown output format: " << outputFormat << std::endl;
+            std::cerr << "unknown output format: " << outputFormatVpc << std::endl;
             return false;
         }
     }
     else
-        outputFormat = "las";  // uncompressed by default
+        outputFormatVpc = "las";  // uncompressed by default
 
     return true;
 }
@@ -187,15 +187,7 @@ void Clip::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipel
             ParallelJobInfo tile(ParallelJobInfo::FileBased, BOX2D(), filterExpression, filterBounds);
             tile.inputFilenames.push_back(f.filename);
 
-            // for input file /x/y/z.las that goes to /tmp/hello.vpc,
-            // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fileStem(f.filename);
-            
-            // if the output is not VPC  las file format is forced to avoid time spent on compression, files will be later merged into single output and removed anyways
-            if (!ends_with(outputFile, ".vpc"))
-                tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
-            else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
+            tile.outputFilename = tileOutputFileName(outputFile, outputFormatVpc, outputSubdir, f.filename);
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/src/filter_noise.cpp
+++ b/src/filter_noise.cpp
@@ -34,7 +34,7 @@ namespace fs = std::filesystem;
 void FilterNoise::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc, "copc");
     
     argAlgorithm = &programArgs.add("algorithm", "Noise filtering algorithm to use: statistical or radius.", algorithm, "statistical");
     argRemoveNoisePoints = &programArgs.add("remove-noise-points", "Remove noise points from the output.", removeNoisePoints, false);
@@ -64,8 +64,6 @@ bool FilterNoise::checkArgs()
             return false;
         }
     }
-    else
-        outputFormatVpc = "las";  // uncompressed by default
 
     if (!argAlgorithm->set())
     {

--- a/src/filter_noise.cpp
+++ b/src/filter_noise.cpp
@@ -34,7 +34,7 @@ namespace fs = std::filesystem;
 void FilterNoise::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormat = &programArgs.add("output-format", "Output format (las/laz/copc)", outputFormat);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc);
     
     argAlgorithm = &programArgs.add("algorithm", "Noise filtering algorithm to use: statistical or radius.", algorithm, "statistical");
     argRemoveNoisePoints = &programArgs.add("remove-noise-points", "Remove noise points from the output.", removeNoisePoints, false);
@@ -56,16 +56,16 @@ bool FilterNoise::checkArgs()
         return false;
     }
 
-    if (argOutputFormat->set())
+    if (argOutputFormatVpc->set())
     {
-        if (outputFormat != "las" && outputFormat != "laz" && outputFormat != "copc")
+        if (outputFormatVpc != "las" && outputFormatVpc != "laz" && outputFormatVpc != "copc")
         {
-            std::cerr << "unknown output format: " << outputFormat << std::endl;
+            std::cerr << "unknown output format: " << outputFormatVpc << std::endl;
             return false;
         }
     }
     else
-        outputFormat = "las";  // uncompressed by default
+        outputFormatVpc = "las";  // uncompressed by default
 
     if (!argAlgorithm->set())
     {
@@ -177,14 +177,7 @@ void FilterNoise::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>
             ParallelJobInfo tile(ParallelJobInfo::FileBased, BOX2D(), filterExpression, filterBounds);
             tile.inputFilenames.push_back(f.filename);
 
-            // for input file /x/y/z.las that goes to /tmp/hello.vpc,
-            // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fileStem(f.filename);
-
-            if (!ends_with(outputFile, ".vpc"))
-                tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
-            else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
+            tile.outputFilename = tileOutputFileName(outputFile, outputFormatVpc, outputSubdir, f.filename);
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/src/filter_noise.cpp
+++ b/src/filter_noise.cpp
@@ -65,6 +65,11 @@ bool FilterNoise::checkArgs()
         }
     }
 
+    if ( ends_with(outputFile, ".vpc") && outputFormatVpc == "copc" )
+    {
+        isStreaming = false;
+    }
+
     if (!argAlgorithm->set())
     {
         std::cerr << "missing algorithm" << std::endl;

--- a/src/height_above_ground.cpp
+++ b/src/height_above_ground.cpp
@@ -35,7 +35,7 @@ namespace fs = std::filesystem;
 void HeightAboveGround::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormatVpc = &programArgs.add("vcp-output-format", "Output format (las/laz/copc)", outputFormatVpc);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc, "copc");
     argAlgorithm = &programArgs.add("algorithm", "Height Above Ground algorithm to use: nn (Nearest Neighbor) or delaunay (Delaunay).", algorithm, "nn");
     argReplaceZWithHeightAboveGround = &programArgs.add("replace-z", "Replace Z dimension with height above ground (true/false).", replaceZWithHeightAboveGround, true);
 
@@ -63,8 +63,6 @@ bool HeightAboveGround::checkArgs()
             return false;
         }
     }
-    else
-        outputFormatVpc = "las";  // uncompressed by default
 
     if (!argAlgorithm->set())
     {

--- a/src/height_above_ground.cpp
+++ b/src/height_above_ground.cpp
@@ -35,7 +35,7 @@ namespace fs = std::filesystem;
 void HeightAboveGround::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormat = &programArgs.add("output-format", "Output format (las/laz/copc)", outputFormat);
+    argOutputFormatVpc = &programArgs.add("vcp-output-format", "Output format (las/laz/copc)", outputFormatVpc);
     argAlgorithm = &programArgs.add("algorithm", "Height Above Ground algorithm to use: nn (Nearest Neighbor) or delaunay (Delaunay).", algorithm, "nn");
     argReplaceZWithHeightAboveGround = &programArgs.add("replace-z", "Replace Z dimension with height above ground (true/false).", replaceZWithHeightAboveGround, true);
 
@@ -55,16 +55,16 @@ bool HeightAboveGround::checkArgs()
         return false;
     }
 
-    if (argOutputFormat->set())
+    if (argOutputFormatVpc->set())
     {
-        if (outputFormat != "las" && outputFormat != "laz" && outputFormat != "copc")
+        if (outputFormatVpc != "las" && outputFormatVpc != "laz" && outputFormatVpc != "copc")
         {
-            std::cerr << "unknown output format: " << outputFormat << std::endl;
+            std::cerr << "unknown output format: " << outputFormatVpc << std::endl;
             return false;
         }
     }
     else
-        outputFormat = "las";  // uncompressed by default
+        outputFormatVpc = "las";  // uncompressed by default
 
     if (!argAlgorithm->set())
     {
@@ -193,14 +193,7 @@ void HeightAboveGround::preparePipelines(std::vector<std::unique_ptr<PipelineMan
             ParallelJobInfo tile(ParallelJobInfo::FileBased, BOX2D(), filterExpression, filterBounds);
             tile.inputFilenames.push_back(f.filename);
 
-            // for input file /x/y/z.las that goes to /tmp/hello.vpc,
-            // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fileStem(f.filename);
-
-            if (!ends_with(outputFile, ".vpc"))
-                tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
-            else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
+            tile.outputFilename = tileOutputFileName(outputFile, outputFormatVpc, outputSubdir, f.filename);
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/src/height_above_ground.cpp
+++ b/src/height_above_ground.cpp
@@ -64,6 +64,11 @@ bool HeightAboveGround::checkArgs()
         }
     }
 
+    if ( ends_with(outputFile, ".vpc") && outputFormatVpc == "copc" )
+    {
+        isStreaming = false;
+    }
+    
     if (!argAlgorithm->set())
     {
         std::cerr << "missing algorithm" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@ TODO:
 
 extern int runTile(std::vector<std::string> arglist);  // tile/tile.cpp
 
-std::string WRENCH_VERSION = "1.3.0";
+std::string WRENCH_VERSION = "1.3.1";
 
 void printUsage()
 {

--- a/src/thin.cpp
+++ b/src/thin.cpp
@@ -87,6 +87,11 @@ bool Thin::checkArgs()
         }
     }
 
+    if ( ends_with(outputFile, ".vpc") && outputFormatVpc == "copc" )
+    {
+        isStreaming = false;
+    }
+    
     return true;
 }
 

--- a/src/thin.cpp
+++ b/src/thin.cpp
@@ -37,7 +37,7 @@ namespace fs = std::filesystem;
 void Thin::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormat = &programArgs.add("output-format", "Output format (las/laz/copc)", outputFormat);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc);
     argMode = &programArgs.add("mode", " 'every-nth' or 'sample' - either to keep every N-th point or to keep points based on their distance", mode);
     argStepEveryN = &programArgs.add("step-every-nth", "Keep every N-th point", stepEveryN);
     argStepSample = &programArgs.add("step-sample", "Minimum spacing between points", stepSample);
@@ -78,16 +78,16 @@ bool Thin::checkArgs()
         return false;
     }
 
-    if (argOutputFormat->set())
+    if (argOutputFormatVpc->set())
     {
-        if (outputFormat != "las" && outputFormat != "laz")
+        if (outputFormatVpc != "las" && outputFormatVpc != "laz" && outputFormatVpc != "copc")
         {
-            std::cerr << "unknown output format: " << outputFormat << std::endl;
+            std::cerr << "unknown output format: " << outputFormatVpc << std::endl;
             return false;
         }
     }
     else
-        outputFormat = "las";  // uncompressed by default
+        outputFormatVpc = "las";  // uncompressed by default
 
     return true;
 }
@@ -163,14 +163,7 @@ void Thin::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& pipel
             ParallelJobInfo tile(ParallelJobInfo::FileBased, BOX2D(), filterExpression, filterBounds);
             tile.inputFilenames.push_back(f.filename);
 
-            // for input file /x/y/z.las that goes to /tmp/hello.vpc,
-            // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fileStem(f.filename);
-
-            if (!ends_with(outputFile, ".vpc"))
-                tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
-            else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
+            tile.outputFilename = tileOutputFileName(outputFile, outputFormatVpc, outputSubdir, f.filename);
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/src/thin.cpp
+++ b/src/thin.cpp
@@ -37,7 +37,7 @@ namespace fs = std::filesystem;
 void Thin::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc, "copc");
     argMode = &programArgs.add("mode", " 'every-nth' or 'sample' - either to keep every N-th point or to keep points based on their distance", mode);
     argStepEveryN = &programArgs.add("step-every-nth", "Keep every N-th point", stepEveryN);
     argStepSample = &programArgs.add("step-sample", "Minimum spacing between points", stepSample);
@@ -86,8 +86,6 @@ bool Thin::checkArgs()
             return false;
         }
     }
-    else
-        outputFormatVpc = "las";  // uncompressed by default
 
     return true;
 }

--- a/src/tile/tile.cpp
+++ b/src/tile/tile.cpp
@@ -442,7 +442,7 @@ void addArgs(pdal::ProgramArgs& programArgs, BaseInfo::Options& options, pdal::A
     programArgs.add("input-file-list", "Read input files from a text file", options.inputFileList);
     programArgs.add("length,l", "Tile length", options.tileLength, 1000.);
     tempArg = &(programArgs.add("temp_dir", "Temp directory", options.tempDir));
-    programArgs.add("vpc-output-format", "Output format (las/laz)", options.outputFormat);
+    programArgs.add("vpc-output-format", "Output format (las/laz/copc)", options.outputFormat);
 
     // for debugging
     programArgs.add("preserve_temp_dir", "Do not remove the temp directory before and after processing (for debugging)",

--- a/src/tile/tile.cpp
+++ b/src/tile/tile.cpp
@@ -442,7 +442,7 @@ void addArgs(pdal::ProgramArgs& programArgs, BaseInfo::Options& options, pdal::A
     programArgs.add("input-file-list", "Read input files from a text file", options.inputFileList);
     programArgs.add("length,l", "Tile length", options.tileLength, 1000.);
     tempArg = &(programArgs.add("temp_dir", "Temp directory", options.tempDir));
-    programArgs.add("output-format", "Output format (las/laz)", options.outputFormat);
+    programArgs.add("vpc-output-format", "Output format (las/laz)", options.outputFormat);
 
     // for debugging
     programArgs.add("preserve_temp_dir", "Do not remove the temp directory before and after processing (for debugging)",

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -34,7 +34,7 @@ namespace fs = std::filesystem;
 void Translate::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc, "copc");
     programArgs.add("assign-crs", "Assigns CRS to data (no reprojection)", assignCrs);
     programArgs.add("transform-crs", "Transforms (reprojects) data to another CRS", transformCrs);
     programArgs.add("transform-coord-op", "Details on how to do the transform of coordinates when --transform-crs is used. "
@@ -62,8 +62,6 @@ bool Translate::checkArgs()
             return false;
         }
     }
-    else
-        outputFormatVpc = "las";  // uncompressed by default
 
     if (!transformCoordOp.empty() && transformCrs.empty())
     {

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -63,6 +63,11 @@ bool Translate::checkArgs()
         }
     }
 
+    if ( ends_with(outputFile, ".vpc") && outputFormatVpc == "copc" )
+    {
+        isStreaming = false;
+    }
+
     if (!transformCoordOp.empty() && transformCrs.empty())
     {
         std::cerr << "Need to specify also --transform-crs when --transform-coord-op is used." << std::endl;

--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -34,7 +34,7 @@ namespace fs = std::filesystem;
 void Translate::addArgs()
 {
     argOutput = &programArgs.add("output,o", "Output point cloud file", outputFile);
-    argOutputFormat = &programArgs.add("output-format", "Output format (las/laz/copc)", outputFormat);
+    argOutputFormatVpc = &programArgs.add("vpc-output-format", "Output format (las/laz/copc)", outputFormatVpc);
     programArgs.add("assign-crs", "Assigns CRS to data (no reprojection)", assignCrs);
     programArgs.add("transform-crs", "Transforms (reprojects) data to another CRS", transformCrs);
     programArgs.add("transform-coord-op", "Details on how to do the transform of coordinates when --transform-crs is used. "
@@ -54,16 +54,16 @@ bool Translate::checkArgs()
     }
 
     // TODO: or use the same format as the reader?
-    if (argOutputFormat->set())
+    if (argOutputFormatVpc->set())
     {
-        if (outputFormat != "las" && outputFormat != "laz")
+        if (outputFormatVpc != "las" && outputFormatVpc != "laz" && outputFormatVpc != "copc")
         {
-            std::cerr << "unknown output format: " << outputFormat << std::endl;
+            std::cerr << "unknown output format: " << outputFormatVpc << std::endl;
             return false;
         }
     }
     else
-        outputFormat = "las";  // uncompressed by default
+        outputFormatVpc = "las";  // uncompressed by default
 
     if (!transformCoordOp.empty() && transformCrs.empty())
     {
@@ -178,14 +178,7 @@ void Translate::preparePipelines(std::vector<std::unique_ptr<PipelineManager>>& 
             ParallelJobInfo tile(ParallelJobInfo::FileBased, BOX2D(), filterExpression, filterBounds);
             tile.inputFilenames.push_back(f.filename);
 
-            // for input file /x/y/z.las that goes to /tmp/hello.vpc,
-            // individual output file will be called /tmp/hello/z.las
-            fs::path inputBasename = fileStem(f.filename);
-
-            if (!ends_with(outputFile, ".vpc"))
-                tile.outputFilename = (outputSubdir / inputBasename).string() + ".las";
-            else
-                tile.outputFilename = (outputSubdir / inputBasename).string() + "." + outputFormat;
+            tile.outputFilename = tileOutputFileName(outputFile, outputFormatVpc, outputSubdir, f.filename);
 
             tileOutputFiles.push_back(tile.outputFilename);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -359,6 +359,8 @@ void buildOutput(std::string outputFile, std::vector<std::string> &tileOutputFil
 
 std::string tileOutputFileName(const std::string &outputFile, const std::string &outputFormat, const fs::path &outputSubdir, const std::string &tileFilename)
 {
+    assert(outputFormat == "las" || outputFormat == "laz" || outputFormat == "copc");
+
     const fs::path inputBasename = fileStem(tileFilename);
 
     // construct full output file name for the tile without extension

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -359,7 +359,7 @@ void buildOutput(std::string outputFile, std::vector<std::string> &tileOutputFil
 
 std::string tileOutputFileName(const std::string &outputFile, const std::string &outputFormat, const fs::path &outputSubdir, const std::string &tileFilename)
 {
-    const fs::path &inputBasename = fileStem(tileFilename);
+    const fs::path inputBasename = fileStem(tileFilename);
 
     // construct full output file name for the tile without extension
     const std::string fullFileNameWithoutExt = (outputSubdir / inputBasename).string();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -356,3 +356,29 @@ void buildOutput(std::string outputFile, std::vector<std::string> &tileOutputFil
         removeFiles(tileOutputFiles, true);
     }
 }
+
+std::string tileOutputFileName(const std::string &outputFile, const std::string &outputFormat, const fs::path &outputSubdir, const std::string &tileFilename)
+{
+    const fs::path &inputBasename = fileStem(tileFilename);
+
+    // construct full output file name for the tile without extension
+    const std::string fullFileNameWithoutExt = (outputSubdir / inputBasename).string();
+
+    // output is not a VPC, it will be merged later into a single file,
+    // use las to avoid zipping the file, it will be removed after merging
+    if (!ends_with(outputFile, ".vpc"))
+    {
+        return fullFileNameWithoutExt + ".las";
+    }
+
+    // output is VPC, use specified output format
+    std::string ext = outputFormat;
+
+    // change extension for copc, user inputed copc as format, but copc.laz is needed as extension
+    if (outputFormat == "copc")
+    {
+        ext = "copc.laz";
+    }
+
+    return fullFileNameWithoutExt + "." + ext;
+}

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -14,7 +14,9 @@
 
 #include <pdal/PipelineManager.hpp>
 #include <mutex>
+#include <filesystem>
 
+namespace fs = std::filesystem;
 using namespace pdal;
 
 // tiling scheme containing tileCountX x tileCountY square tiles of tileSize x tileSize,
@@ -275,3 +277,7 @@ pdal::Stage &makeWriter(pdal::PipelineManager *manager, const std::string &outpu
  */
 void buildOutput(std::string outputFile, std::vector<std::string> &tileOutputFiles);
 
+/**
+ * Generate tile output file name based on outputFile and outputFormat.
+ */
+std::string tileOutputFileName(const std::string &outputFile, const std::string &outputFormat, const fs::path &outputSubdir, const std::string &tileFilename);

--- a/tests/test_classify_ground.py
+++ b/tests/test_classify_ground.py
@@ -106,3 +106,51 @@ def test_classify_ground(input_path: Path, output_path: Path, point_count: int):
     number_of_points = pipeline.execute()
 
     assert number_of_points == point_count
+
+
+def test_classify_ground_vpc_with_las_output_format():
+    input_path = utils.test_data_filepath("data.vpc")
+
+    vpc_las_output_path = utils.test_data_output_filepath("classify-ground-las.vpc", "classify_ground")
+
+    res = subprocess.run(
+        [
+            utils.pdal_wrench_path(),
+            "classify_ground",
+            f"--input={input_path.as_posix()}",
+            f"--output={vpc_las_output_path.as_posix()}",
+            "--vpc-output-format=las",
+        ],
+        check=True,
+    )
+
+    assert res.returncode == 0
+
+    output_subfolder = vpc_las_output_path.parent / vpc_las_output_path.stem
+
+    assert output_subfolder.exists()
+    assert all([x.suffix == ".las" for x in output_subfolder.iterdir()])
+
+
+def test_classify_ground_vpc_with_default_output_format():
+
+    input_path = utils.test_data_filepath("data.vpc")
+
+    vpc_copc_laz_output_path = utils.test_data_output_filepath("classify-ground-copc-laz.vpc", "classify_ground")
+
+    res = subprocess.run(
+        [
+            utils.pdal_wrench_path(),
+            "classify_ground",
+            f"--input={input_path.as_posix()}",
+            f"--output={vpc_copc_laz_output_path.as_posix()}",
+        ],
+        check=True,
+    )
+
+    assert res.returncode == 0
+
+    output_subfolder = vpc_copc_laz_output_path.parent / vpc_copc_laz_output_path.stem
+
+    assert output_subfolder.exists()
+    assert all([x.suffixes == [".copc", ".laz"] for x in output_subfolder.iterdir()])

--- a/tests/test_classify_ground.py
+++ b/tests/test_classify_ground.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 from pathlib import Path
 
@@ -154,3 +155,30 @@ def test_classify_ground_vpc_with_default_output_format():
 
     assert output_subfolder.exists()
     assert all([x.suffixes == [".copc", ".laz"] for x in output_subfolder.iterdir()])
+
+    # verify VPC content
+    vpc_content = json.loads(vpc_copc_laz_output_path.read_text())
+
+    # number of files in VPC
+    assert len(vpc_content["features"]) == 4
+
+    # check bbox of first and last file
+    first_file_bbox = vpc_content["features"][0]["bbox"]
+    assert first_file_bbox == [
+        -123.07031171500326,
+        44.05891131812414,
+        127.44,
+        -123.06893735490084,
+        44.05985282878156,
+        167.160,
+    ]
+
+    last_file_bbox = vpc_content["features"][3]["bbox"]
+    assert last_file_bbox == [
+        -123.06893723004889,
+        44.05792178151518,
+        126.65,
+        -123.06756285690368,
+        44.058912974549095,
+        160.16,
+    ]


### PR DESCRIPTION
Update VPC handling:

- rename wrench argument to **vpc-output-format** for clarity
- handle issue with wrong suffix for **copc** files to properly be set to **.copc.laz** 
- set format of individual files to **COPC** by default for **VPC** (previously the format was **LAS**)  