### PR TITLE
Add support for multiple tiled vpc overviews

### DIFF
--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -10,6 +10,7 @@
  *                                                                           *
  ****************************************************************************/
 
+#include <algorithm>
 #include <iostream>
 #include <fstream>
 #include <filesystem>
@@ -152,17 +153,20 @@ bool VirtualPointCloud::read(std::string filename)
                                         statsItem["variance"]));
             }
 
-            // read overview file (if any, expecting at most one)
-            // this logic is very basic, we should be probably checking roles of assets
-            if (f["assets"].contains("overview"))
+            // read overview files (assets with "overview" role)
+            for (auto &asset : f["assets"])
             {
-                vpcf.overviewFilename = f["assets"]["overview"]["href"];
+                if (!asset.contains("roles") || !asset["roles"].is_array())
+                    continue;
 
-                if (vpcf.overviewFilename.substr(0, 2) == "./")
-                {
-                    // resolve relative path
-                    vpcf.overviewFilename = fs::weakly_canonical(filenameParent / vpcf.overviewFilename).string();
-                }
+                const auto roles = asset["roles"];
+                if (std::find(roles.cbegin(), roles.cend(), "overview") == roles.cend())
+                    continue;
+
+                std::string ovFilename = asset["href"];
+                if (ovFilename.substr(0, 2) == "./")
+                    ovFilename = fs::weakly_canonical(filenameParent / ovFilename).string();
+                vpcf.overviewFilenames.push_back(ovFilename);
             }
 
             files.push_back(vpcf);
@@ -311,26 +315,20 @@ bool VirtualPointCloud::write(std::string filename)
         };
         nlohmann::json assets = { { "data", dataAsset } };
 
-        if (!f.overviewFilename.empty())
+        for (size_t i = 0; i < f.overviewFilenames.size(); ++i)
         {
-            std::string overviewFilename;
-            if (pdal::Utils::isRemote(f.overviewFilename))
+            std::string ovFilename(f.overviewFilenames[i]);
+            if (!pdal::Utils::isRemote(ovFilename))
             {
-                // keep remote URLs as they are
-                overviewFilename = f.overviewFilename;
+                const fs::path fRelative = fs::relative(ovFilename, outputPath);
+                ovFilename = "./" + fRelative.string();
             }
-            else
-            {
-                // turn local paths to relative
-                fs::path fRelative = fs::relative(f.overviewFilename, outputPath);
-                overviewFilename = "./" + fRelative.string();
-            }
-
+            const std::string key = f.overviewFilenames.size() > 1 ? ("overview-" + std::to_string(i + 1)) : "overview";
             nlohmann::json overviewAsset = {
-                { "href", overviewFilename },
+                { "href", ovFilename },
                 { "roles", json::array({"overview"}) },
             };
-            assets["overview"] = overviewAsset;
+            assets[key] = overviewAsset;
         }
 
         jFiles.push_back(
@@ -418,6 +416,7 @@ void buildVpc(std::vector<std::string> args)
     bool boundaries = false;
     bool stats = false;
     bool overview = false;
+    double overviewLength = 0.0;
     int max_threads = -1;
     bool verbose = false;
     bool help = false;
@@ -430,6 +429,9 @@ void buildVpc(std::vector<std::string> args)
     programArgs.add("boundary", "Calculate boundary polygons from data", boundaries);
     programArgs.add("stats", "Calculate statistics from data", stats);
     programArgs.add("overview", "Create overview point cloud from source data", overview);
+    programArgs.add("overview-length",
+        "Split overview into multiple tiles of specified maximum edge length in CRS units (implies --overview)",
+        overviewLength);
 
     pdal::Arg& argThreads = programArgs.add("threads", "Max number of concurrent threads for parallel runs", max_threads);
     programArgs.add("verbose", "Print extra debugging output", verbose);
@@ -550,16 +552,74 @@ void buildVpc(std::vector<std::string> args)
 
     //
 
-    std::string overviewFilenameBase, overviewFilenameCopc;
-    std::vector<std::string> overviewTempFiles;
-    int overviewCounter = 0;
+    if (overviewLength > 0.0)
+        overview = true;
+
+    std::string overviewFilenameBase;
     if (overview)
     {
-        // for /tmp/hello.vpc we will use /tmp/hello-overview.laz as overview file
-        fs::path outputParentDir = fs::path(outputFile).parent_path();
-        fs::path outputStem = outputParentDir / fs::path(outputFile).stem();
+        // for /tmp/hello.vpc we will use /tmp/hello-overview.copc.laz as overview file
+        // if multiple overview tiles are generated, we will use /tmp/hello-overview-1.copc.laz etc.
+        const fs::path outputParentDir = fs::path(outputFile).parent_path();
+        const fs::path outputStem = outputParentDir / fs::path(outputFile).stem();
         overviewFilenameBase = outputStem.string();
-        overviewFilenameCopc = outputStem.string() + "-overview.copc.laz";
+    }
+
+    // Compute overview tiling grid
+    int numOverviewX = 1, numOverviewY = 1;
+    const BOX2D totalBox = vpc.box3d().to2d();
+
+    if (overview && overviewLength > 0.0)
+    {
+        const double totalW = totalBox.maxx - totalBox.minx;
+        const double totalH = totalBox.maxy - totalBox.miny;
+        numOverviewX = std::max(1, static_cast<int>(std::ceil(totalW / overviewLength)));
+        numOverviewY = std::max(1, static_cast<int>(std::ceil(totalH / overviewLength)));
+    }
+
+    const int numOverviewTiles = numOverviewX * numOverviewY;
+    const bool multiOverview = numOverviewTiles > 1;
+
+    struct OverviewTile {
+        BOX2D bbox;
+        std::string copcFilename;
+        std::vector<std::string> tempFiles;
+    };
+    std::vector<OverviewTile> overviewTiles;
+
+    if (overview)
+    {
+        overviewTiles.reserve(numOverviewTiles);
+        int overviewCounter = 0;
+        for (int iy = 0; iy < numOverviewY; ++iy)
+        {
+            for (int ix = 0; ix < numOverviewX; ++ix)
+            {
+                if (multiOverview)
+                {
+                    OverviewTile ovTile;
+                    ovTile.bbox = BOX2D(totalBox.minx + ix * overviewLength,
+                                        totalBox.miny + iy * overviewLength,
+                                        totalBox.minx + (ix + 1) * overviewLength,
+                                        totalBox.miny + (iy + 1) * overviewLength);
+
+                    // overview tiles are on a grid, some might not overlap with vpc files
+                    // so we skip them to preserve continuous filename numbering
+                    if (vpc.overlappingBox2D(ovTile.bbox).empty())
+                        continue;
+
+                    ovTile.copcFilename = overviewFilenameBase + "-overview-" + std::to_string(++overviewCounter) + ".copc.laz";
+                    overviewTiles.push_back(ovTile);
+                }
+                else
+                {
+                    OverviewTile ovTile;
+                    ovTile.bbox = totalBox;
+                    ovTile.copcFilename = overviewFilenameBase + "-overview.copc.laz";
+                    overviewTiles.push_back(ovTile);
+                }
+            }
+        }
     }
 
     if (boundaries || stats || overview)
@@ -567,83 +627,140 @@ void buildVpc(std::vector<std::string> args)
         std::map<std::string, Stage*> hexbinFilters, statsFilters;
         std::vector<std::unique_ptr<PipelineManager>> pipelines;
 
+        int overviewCounter = 0;
         for (VirtualPointCloud::File &f : vpc.files)
         {
-            std::unique_ptr<PipelineManager> manager( new PipelineManager );
-
-            Stage* last = &makeReader(manager.get(), f.filename);
-            if (boundaries)
+            if (overview && multiOverview)
             {
-                pdal::Options hexbin_opts;
-                // TODO: any options?
-                last = &manager->makeFilter( "filters.hexbin", *last, hexbin_opts );
-                hexbinFilters[f.filename] = last;
+                // For multi-tile overview: one pipeline per (source file, tile) combination
+                for (OverviewTile &tile : overviewTiles)
+                {
+                    if (!tile.bbox.overlaps(f.bbox.to2d()))
+                        continue;
+
+                    std::unique_ptr<PipelineManager> manager( new PipelineManager );
+                    Stage* last = &makeReader(manager.get(), f.filename);
+
+                    pdal::Options crop_opts;
+                    crop_opts.add(pdal::Option("bounds", box_to_pdal_bounds(tile.bbox)));
+                    last = &manager->makeFilter("filters.crop", *last, crop_opts);
+
+                    pdal::Options decim_opts;
+                    decim_opts.add(pdal::Option("step", 1000));
+                    last = &manager->makeFilter("filters.decimation", *last, decim_opts);
+
+                    const std::string overviewOutput = overviewFilenameBase + "-overview-tmp-" + std::to_string(++overviewCounter) + ".las";
+                    tile.tempFiles.push_back(overviewOutput);
+                    makeWriter(manager.get(), overviewOutput, last);
+                    pipelines.push_back(std::move(manager));
+                }
+
+                // Boundaries/stats for multi-overview still need a separate pipeline per file
+                if (boundaries || stats)
+                {
+                    std::unique_ptr<PipelineManager> manager( new PipelineManager );
+                    Stage* last = &makeReader(manager.get(), f.filename);
+                    if (boundaries)
+                    {
+                        pdal::Options hexbin_opts;
+                        last = &manager->makeFilter("filters.hexbin", *last, hexbin_opts);
+                        hexbinFilters[f.filename] = last;
+                    }
+                    if (stats)
+                    {
+                        pdal::Options stats_opts;
+                        last = &manager->makeFilter("filters.stats", *last, stats_opts);
+                        statsFilters[f.filename] = last;
+                    }
+                    pipelines.push_back(std::move(manager));
+                }
             }
-
-            if (stats)
+            else
             {
-                pdal::Options stats_opts;
-                // TODO: any options?
-                last = &manager->makeFilter( "filters.stats", *last, stats_opts );
-                statsFilters[f.filename] = last;
+                std::unique_ptr<PipelineManager> manager( new PipelineManager );
+
+                Stage* last = &makeReader(manager.get(), f.filename);
+                if (boundaries)
+                {
+                    pdal::Options hexbin_opts;
+                    // TODO: any options?
+                    last = &manager->makeFilter( "filters.hexbin", *last, hexbin_opts );
+                    hexbinFilters[f.filename] = last;
+                }
+
+                if (stats)
+                {
+                    pdal::Options stats_opts;
+                    // TODO: any options?
+                    last = &manager->makeFilter( "filters.stats", *last, stats_opts );
+                    statsFilters[f.filename] = last;
+                }
+
+                if (overview)
+                {
+                    // TODO: configurable method and step size?
+                    pdal::Options decim_opts;
+                    decim_opts.add(pdal::Option("step", 1000));
+                    last = &manager->makeFilter( "filters.decimation", *last, decim_opts );
+
+                    const std::string overviewOutput = overviewFilenameBase + "-overview-tmp-" + std::to_string(++overviewCounter) + ".las";
+                    overviewTiles[0].tempFiles.push_back(overviewOutput);
+
+                    makeWriter(manager.get(), overviewOutput, last);
+                }
+
+                pipelines.push_back(std::move(manager));
             }
-
-            if (overview)
-            {
-                // TODO: configurable method and step size?
-                pdal::Options decim_opts;
-                decim_opts.add(pdal::Option("step", 1000));
-                last = &manager->makeFilter( "filters.decimation", *last, decim_opts );
-
-                std::string overviewOutput = overviewFilenameBase + "-overview-tmp-" + std::to_string(++overviewCounter) + ".las";
-                overviewTempFiles.push_back(overviewOutput);
-
-                makeWriter(manager.get(), overviewOutput, last);
-              }
-
-            pipelines.push_back(std::move(manager));
         }
 
         runPipelineParallel(vpc.totalPoints(), true, pipelines, max_threads, verbose);
 
         if (overview)
         {
-            // When doing overviews, this is the second stage where we index overview point cloud.
+            // When doing overviews, this is the second stage where we index overview point cloud(s).
             // We do it separately because writers.copc is not streamable. We could also use
             // untwine instead of writers.copc...
 
-            std::unique_ptr<PipelineManager> manager( new PipelineManager );
             std::vector<std::unique_ptr<PipelineManager>> pipelinesCopcOverview;
 
-            // TODO: I am not really sure why we need a merge filter, but without it
-            // I am only getting points in output COPC from the last reader. Example
-            // from the documentation suggests the merge filter should not be needed:
-            // https://pdal.io/en/latest/stages/writers.copc.html
-
-            Stage &merge = manager->makeFilter("filters.merge");
-
-            pdal::Options writer_opts;
-            //writer_opts.add(pdal::Option("forward", "all"));
-            Stage& writer = manager->makeWriter(overviewFilenameCopc, "writers.copc", merge, writer_opts);
-            (void)writer;
-
-            for (const std::string &overviewTempFile : overviewTempFiles)
+            for (const OverviewTile &tile : overviewTiles)
             {
-                Stage& reader = makeReader(manager.get(), overviewTempFile);
-                merge.setInput(reader);
+                if (tile.tempFiles.empty())
+                    continue;
+
+                std::unique_ptr<PipelineManager> manager( new PipelineManager );
+
+                // TODO: I am not really sure why we need a merge filter, but without it
+                // I am only getting points in output COPC from the last reader. Example
+                // from the documentation suggests the merge filter should not be needed:
+                // https://pdal.io/en/latest/stages/writers.copc.html
+
+                Stage &merge = manager->makeFilter("filters.merge");
+
+                pdal::Options writer_opts;
+                Stage& writer = manager->makeWriter(tile.copcFilename, "writers.copc", merge, writer_opts);
+                (void)writer;
+
+                for (const std::string &tempFile : tile.tempFiles)
+                {
+                    Stage& reader = makeReader(manager.get(), tempFile);
+                    merge.setInput(reader);
+                }
+
+                pipelinesCopcOverview.push_back(std::move(manager));
             }
 
             if (verbose)
             {
-                std::cout << "Indexing overview point cloud..." << std::endl;
+                std::cout << "Indexing overview point cloud(s)..." << std::endl;
             }
-            pipelinesCopcOverview.push_back(std::move(manager));
             runPipelineParallel(vpc.totalPoints()/1000, false, pipelinesCopcOverview, max_threads, verbose);
 
             // delete tmp overviews
-            for (const std::string &overviewTempFile : overviewTempFiles)
+            for (const OverviewTile &tile : overviewTiles)
             {
-                std::filesystem::remove(overviewTempFile);
+                for (const std::string &tempFile : tile.tempFiles)
+                    std::filesystem::remove(tempFile);
             }
         }
 
@@ -676,7 +793,17 @@ void buildVpc(std::vector<std::string> args)
             }
             if (overview)
             {
-                f.overviewFilename = overviewFilenameCopc;
+                for (const OverviewTile &tile : overviewTiles)
+                {
+                    if (tile.tempFiles.empty())
+                        continue; // empty tile (no source files)
+                    // we can't use overlaps() here as we don't want to include bboxes that only touch
+                    if (tile.bbox.minx < f.bbox.maxx &&
+                            tile.bbox.maxx > f.bbox.minx &&
+                            tile.bbox.miny < f.bbox.maxy &&
+                            tile.bbox.maxy > f.bbox.miny)
+                        f.overviewFilenames.push_back(tile.copcFilename);
+                }
             }
         }
     }

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -574,8 +574,8 @@ void buildVpc(std::vector<std::string> args)
     {
         const double totalW = totalBox.maxx - totalBox.minx;
         const double totalH = totalBox.maxy - totalBox.miny;
-        numOverviewX = std::max(1, static_cast<int>(std::ceil(totalW / overviewLength)));
-        numOverviewY = std::max(1, static_cast<int>(std::ceil(totalH / overviewLength)));
+        numOverviewX = (std::max)(1, static_cast<int>(std::ceil(totalW / overviewLength)));
+        numOverviewY = (std::max)(1, static_cast<int>(std::ceil(totalH / overviewLength)));
     }
 
     const int numOverviewTiles = numOverviewX * numOverviewY;

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -11,6 +11,7 @@
  ****************************************************************************/
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <fstream>
 #include <filesystem>

--- a/src/vpc.hpp
+++ b/src/vpc.hpp
@@ -64,9 +64,9 @@ struct VirtualPointCloud
         std::vector<SchemaItem> schema;  // we're not using it, just for STAC export
         std::vector<StatsItem> stats;
 
-        // support for overview point clouds - currently we assume a file refers to at most a single overview file
-        // (when building VPC with overviews, we create one overview file for all source data)
-        std::string overviewFilename;
+        // support for overview point clouds - a file may refer to one or more overview files
+        // (when building VPC with overviews, multiple overview tiles may be created)
+        std::vector<std::string> overviewFilenames;
     };
 
     std::vector<File> files;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,7 @@ def _prepare_data():
 
     assert number_points == 338163
 
-    # build vpc file with copc files
+    # build vpc file with copc files and tiled overviews
     vpc_copc_file = utils.test_data_filepath("data_copc.vpc")
 
     if not vpc_copc_file.exists():
@@ -156,6 +156,8 @@ def _prepare_data():
             [
                 utils.pdal_wrench_path(),
                 "build_vpc",
+                "--overview-length",
+                "150",
                 "--output",
                 vpc_copc_file.as_posix(),
                 *[f.as_posix() for f in files_for_vpc_copc],
@@ -171,6 +173,13 @@ def _prepare_data():
     number_points = vpc_copc.execute()
 
     assert number_points == 338163
+
+    assert not utils.test_data_filepath("data_copc-overview.copc.laz").exists()
+    assert utils.test_data_filepath("data_copc-overview-1.copc.laz").exists()
+    assert utils.test_data_filepath("data_copc-overview-2.copc.laz").exists()
+    assert utils.test_data_filepath("data_copc-overview-3.copc.laz").exists()
+    assert utils.test_data_filepath("data_copc-overview-4.copc.laz").exists()
+    assert not utils.test_data_filepath("data_copc-overview-5.copc.laz").exists()
 
     # build vpz file with copc files
     vpz_copc_file = utils.test_data_filepath("data_copc.vpz")

--- a/vpc-spec.md
+++ b/vpc-spec.md
@@ -60,11 +60,11 @@ Overviews are an optional feature, they do not need to be provided.
 
 In a simple case, there would be a single overview point cloud for a whole VPC - using thinned original data (e.g. every 1000-th point) and merged from individual data files to a single file.
 
-In case of very large point clouds, using a single overview point cloud may not be enough, and it may be useful to have a hierarchy of overviews with a tiling scheme (e.g.  1 overview at level 0, 4 overviews at level 1, 16 overviews at level 2 - each level having different density).
+In case of very large point clouds, using a single overview point cloud may be too large, and it may be useful to split it into multiple overviews using a tiling scheme.
 
 Overviews are defined as extra assets of STAC items in addition to the actual data file - it is expected that they have `overview` role defined. An overview point cloud may be referenced from multiple STAC items.
 
-In case of a hierarchy of overviews, each STAC item may have multiple overview assets linked (e.g. one for level 0, one for level 1, one for level 2). STAC protocol does not provide a way to distinguish which overview is at what level (no place to write spacing between points or density), it is up to the client software to collect all referenced overviews and query their properties.
+In case of tiled overviews, each STAC item may have multiple overview assets linked. All overviews that spatialy intersect the STAC item should be included. STAC protocol does not provide a way to list all linked overview tiles, it is up to the client software to collect all referenced overviews, deduplicate them and query their properties.
 
 A sample of encoding overview point cloud in addition to the actual data:
 ```json


### PR DESCRIPTION
Allow creating multiple tiled overview files for a vpc.
A new option `--overview-length` is added to `pdal_wrench build_vpc`.
The name is modeled after `pdal split`'s and `pdal tile`'s `--length` parameter, and sets the maximum length/width of overview files to generate.
The decimation logic is preserved (still picking every 1000th point) but the output is tiled on a grid of size `overview-length`, generating files named `<stem>-overview-1.copc.laz` etc.
All overviews intersecting a vpc's file are added as extra assets with role `overview`.
