### PR TITLE
Add libzip to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN ash <<'EOF'
         cmake \
         g++ \
         git \
+        libzip-dev \
         make \
         pdal-dev \
     ;


### PR DESCRIPTION
Try to fix the failing workflow.
Not sure why it did not fail for #84 runs that introduced the dependency.