### PR TITLE
Fix remote VPC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ TODO:
 
 extern int runTile(std::vector<std::string> arglist);  // tile/tile.cpp
 
-std::string WRENCH_VERSION = "1.4.0";
+std::string WRENCH_VERSION = "1.5.0";
 
 void printUsage()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ TODO:
 
 extern int runTile(std::vector<std::string> arglist);  // tile/tile.cpp
 
-std::string WRENCH_VERSION = "1.5.0";
+std::string WRENCH_VERSION = "1.5.1";
 
 void printUsage()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ TODO:
 
 extern int runTile(std::vector<std::string> arglist);  // tile/tile.cpp
 
-std::string WRENCH_VERSION = "1.4.1";
+std::string WRENCH_VERSION = "1.5.0";
 
 void printUsage()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ TODO:
 
 extern int runTile(std::vector<std::string> arglist);  // tile/tile.cpp
 
-std::string WRENCH_VERSION = "1.5.1";
+std::string WRENCH_VERSION = "1.4.1";
 
 void printUsage()
 {

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -57,7 +57,8 @@ bool VirtualPointCloud::read(std::string filename)
 {
     clear();
 
-    std::string originalFilename = filename;
+    fs::path filenameParent = fs::path(filename).parent_path();
+    
     std::string downloadedFilename;
     if (pdal::Utils::isRemote(filename))
     {
@@ -66,7 +67,6 @@ bool VirtualPointCloud::read(std::string filename)
     // if downloaded file is not empty, use it as the filename to read, otherwise use the original filename
     filename = downloadedFilename.empty() ? filename : downloadedFilename;
 
-    fs::path filenameParent = fs::path(filename).parent_path();
 
     json data;
 
@@ -211,7 +211,6 @@ bool VirtualPointCloud::read(std::string filename)
 
             if (vpcf.filename.substr(0, 2) == "./")
             {
-                // resolve relative path
                 vpcf.filename = fs::weakly_canonical(filenameParent / vpcf.filename).string();
             }
 

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -57,17 +57,22 @@ bool VirtualPointCloud::read(std::string filename)
 {
     clear();
 
-    fs::path filenameParent = fs::path(filename).parent_path();
-    
+    // this variable is necessary to resolve individual files relative to the VPC original location
+    std::string remoteBase;
     std::string downloadedFilename;
     if (pdal::Utils::isRemote(filename))
     {
         downloadedFilename = pdal::Utils::fetchRemote(filename);
+        size_t lastSlash = filename.rfind('/');
+        remoteBase = (lastSlash != std::string::npos)
+                         ? filename.substr(0, lastSlash + 1)
+                         : "";
     }
     // if downloaded file is not empty, use it as the filename to read, otherwise use the original filename
     filename = downloadedFilename.empty() ? filename : downloadedFilename;
 
-
+    fs::path filenameParent = fs::path(filename).parent_path();
+    
     json data;
 
     if (ends_with(filename, ".vpz"))
@@ -211,7 +216,14 @@ bool VirtualPointCloud::read(std::string filename)
 
             if (vpcf.filename.substr(0, 2) == "./")
             {
-                vpcf.filename = fs::weakly_canonical(filenameParent / vpcf.filename).string();
+                if (downloadedFilename.empty())
+                {
+                    vpcf.filename = fs::weakly_canonical(filenameParent / vpcf.filename).string();
+                }
+                else
+                {
+                    vpcf.filename = remoteBase + vpcf.filename.substr(2); 
+                }
             }
 
             for (auto &schemaItem : f["properties"]["pc:schemas"])
@@ -245,7 +257,16 @@ bool VirtualPointCloud::read(std::string filename)
 
                 std::string ovFilename = asset["href"];
                 if (ovFilename.substr(0, 2) == "./")
-                    ovFilename = fs::weakly_canonical(filenameParent / ovFilename).string();
+                {
+                    if (downloadedFilename.empty())
+                    {
+                        ovFilename = fs::weakly_canonical(filenameParent / ovFilename).string();
+                    }
+                    else
+                    {
+                        ovFilename = remoteBase + ovFilename.substr(2);
+                    }
+                }
                 vpcf.overviewFilenames.push_back(ovFilename);
             }
 

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -40,6 +40,13 @@ using namespace pdal;
 void VirtualPointCloud::clear()
 {
     files.clear();
+
+    // remove the temporary local copy of a remote VPC, if one was downloaded
+    if (!downloadedFilename.empty()) {
+      std::error_code ec;
+      fs::remove(downloadedFilename, ec);
+      downloadedFilename.clear();
+    }
 }
 
 void VirtualPointCloud::dump()
@@ -994,13 +1001,4 @@ std::vector<VirtualPointCloud::File> VirtualPointCloud::overlappingBox2D(const B
     return overlaps;
 }
 
-VirtualPointCloud::~VirtualPointCloud() { cleanup(); }
-
-void VirtualPointCloud::cleanup() {
-  // remove the temporary local copy of a remote VPC, if one was downloaded
-  if (!downloadedFilename.empty()) {
-    std::error_code ec;
-    fs::remove(downloadedFilename, ec);
-    downloadedFilename.clear();
-  }
-}
+VirtualPointCloud::~VirtualPointCloud() { clear(); }

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -135,6 +135,8 @@ bool VirtualPointCloud::read(std::string filename)
         if (!inputJson.good())
         {
             std::cerr << "Failed to read input VPC file: " << filename << std::endl;
+            if (!downloadedFilename.empty())
+              fs::remove(downloadedFilename);
             return false;
         }
 
@@ -145,8 +147,13 @@ bool VirtualPointCloud::read(std::string filename)
         catch (std::exception &e)
         {
             std::cerr << "JSON parsing error: " << e.what() << std::endl;
+            if (!downloadedFilename.empty())
+                fs::remove(downloadedFilename);
             return false;
         }
+
+        if (!downloadedFilename.empty())
+            fs::remove(downloadedFilename);
     }
 
     if (data["type"] != "FeatureCollection")

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -57,6 +57,15 @@ bool VirtualPointCloud::read(std::string filename)
 {
     clear();
 
+    std::string originalFilename = filename;
+    std::string downloadedFilename;
+    if (pdal::Utils::isRemote(filename))
+    {
+        downloadedFilename = pdal::Utils::fetchRemote(filename);
+    }
+    // if downloaded file is not empty, use it as the filename to read, otherwise use the original filename
+    filename = downloadedFilename.empty() ? filename : downloadedFilename;
+
     fs::path filenameParent = fs::path(filename).parent_path();
 
     json data;

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -56,10 +56,10 @@ void VirtualPointCloud::dump()
 bool VirtualPointCloud::read(std::string filename)
 {
     clear();
+    cleanup();
 
     // this variable is necessary to resolve individual files relative to the VPC original location
     std::string remoteBase;
-    std::string downloadedFilename;
     if (pdal::Utils::isRemote(filename))
     {
         downloadedFilename = pdal::Utils::fetchRemote(filename);
@@ -999,4 +999,15 @@ std::vector<VirtualPointCloud::File> VirtualPointCloud::overlappingBox2D(const B
             overlaps.push_back(f);
     }
     return overlaps;
+}
+
+VirtualPointCloud::~VirtualPointCloud() { cleanup(); }
+
+void VirtualPointCloud::cleanup() {
+  // remove the temporary local copy of a remote VPC, if one was downloaded
+  if (!downloadedFilename.empty()) {
+    std::error_code ec;
+    fs::remove(downloadedFilename, ec);
+    downloadedFilename.clear();
+  }
 }

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -63,7 +63,6 @@ void VirtualPointCloud::dump()
 bool VirtualPointCloud::read(std::string filename)
 {
     clear();
-    cleanup();
 
     // this variable is necessary to resolve individual files relative to the VPC original location
     std::string remoteBase;

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -140,8 +140,6 @@ bool VirtualPointCloud::read(std::string filename)
         if (!inputJson.good())
         {
             std::cerr << "Failed to read input VPC file: " << filename << std::endl;
-            if (!downloadedFilename.empty())
-              fs::remove(downloadedFilename);
             return false;
         }
 
@@ -152,13 +150,8 @@ bool VirtualPointCloud::read(std::string filename)
         catch (std::exception &e)
         {
             std::cerr << "JSON parsing error: " << e.what() << std::endl;
-            if (!downloadedFilename.empty())
-                fs::remove(downloadedFilename);
             return false;
         }
-
-        if (!downloadedFilename.empty())
-            fs::remove(downloadedFilename);
     }
 
     if (data["type"] != "FeatureCollection")

--- a/src/vpc.hpp
+++ b/src/vpc.hpp
@@ -68,9 +68,15 @@ struct VirtualPointCloud
         // (when building VPC with overviews, multiple overview tiles may be created)
         std::vector<std::string> overviewFilenames;
     };
+    
+    ~VirtualPointCloud();
 
     std::vector<File> files;
     std::string crsWkt;  // valid WKT for CRS of all files (or empty string if undefined, or "_mix_" if a mixture of CRS was seen)
+    std::string downloadedFilename;  // local copy of a remote VPC fetched in read()
+
+    //! removes the temporary local copy of a remote VPC, if one was downloaded
+    void cleanup();
 
     void clear();
     void dump();

--- a/src/vpc.hpp
+++ b/src/vpc.hpp
@@ -75,9 +75,6 @@ struct VirtualPointCloud
     std::string crsWkt;  // valid WKT for CRS of all files (or empty string if undefined, or "_mix_" if a mixture of CRS was seen)
     std::string downloadedFilename;  // local copy of a remote VPC fetched in read()
 
-    //! removes the temporary local copy of a remote VPC, if one was downloaded
-    void cleanup();
-
     void clear();
     void dump();
     bool read(std::string filename);

--- a/tests/data/stadium.vpc
+++ b/tests/data/stadium.vpc
@@ -1,0 +1,212 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "stac_extensions": [
+        "https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+      ],
+      "id": "stadium-utm",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -123.07030806277363,
+              44.0567662598593,
+              126.64
+            ],
+            [
+              -123.07031177383075,
+              44.05990169102702,
+              126.64
+            ],
+            [
+              -123.06654779900845,
+              44.059903944303535,
+              182.32
+            ],
+            [
+              -123.06654428658233,
+              44.05676851281813,
+              182.32
+            ],
+            [
+              -123.07030806277363,
+              44.0567662598593,
+              126.64
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "bbox": [
+        -123.07031177383075,
+        44.0567662598593,
+        126.64,
+        -123.06654428658233,
+        44.059903944303535,
+        182.32
+      ],
+      "properties": {
+        "datetime": "2013-07-17T00:00:00Z",
+        "pc:count": 693895,
+        "pc:encoding": "?",
+        "pc:schemas": [
+          {
+            "name": "X",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Y",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Z",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Intensity",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "ReturnNumber",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "NumberOfReturns",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanDirectionFlag",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "EdgeOfFlightLine",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Classification",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Synthetic",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "KeyPoint",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Withheld",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "Overlap",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "ScanAngleRank",
+            "size": 4,
+            "type": "floating"
+          },
+          {
+            "name": "UserData",
+            "size": 1,
+            "type": "unsigned"
+          },
+          {
+            "name": "PointSourceId",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "GpsTime",
+            "size": 8,
+            "type": "floating"
+          },
+          {
+            "name": "Red",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "Green",
+            "size": 2,
+            "type": "unsigned"
+          },
+          {
+            "name": "Blue",
+            "size": 2,
+            "type": "unsigned"
+          }
+        ],
+        "pc:type": "lidar",
+        "proj:bbox": [
+          494367.91,
+          4878180.65,
+          126.64,
+          494669.38,
+          4878528.9,
+          182.32
+        ],
+        "proj:geometry": {
+          "coordinates": [
+            [
+              [
+                494367.91,
+                4878180.65,
+                126.64
+              ],
+              [
+                494367.91,
+                4878528.9,
+                126.64
+              ],
+              [
+                494669.38,
+                4878528.9,
+                182.32
+              ],
+              [
+                494669.38,
+                4878180.65,
+                182.32
+              ],
+              [
+                494367.91,
+                4878180.65,
+                126.64
+              ]
+            ]
+          ],
+          "type": "Polygon"
+        },
+        "proj:wkt2": "PROJCS[\"NAD83 / UTM zone 10N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4269\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-123],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"26910\"]]"
+      },
+      "links": [],
+      "assets": {
+        "data": {
+          "href": "https://media.githubusercontent.com/media/PDAL/data/refs/heads/main/autzen/stadium-utm.laz",
+          "roles": [
+            "data"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -51,6 +51,7 @@ def test_input_file_output_file(
         (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("clipped-vpc-copc-files.copc.laz")),
         (utils.test_data_filepath("data_copc.vpz"), utils.test_data_filepath("clipped-vpz-copc-files.vpc")),
         (utils.test_data_filepath("data_copc.vpz"), utils.test_data_filepath("clipped-vpz-copc-files.copc.laz")),
+        ("https://raw.githubusercontent.com/PDAL/wrench/refs/heads/fix-remote-vpc/tests/data/stadium.vpc", utils.test_data_filepath("clipped-vpz-copc-files.copc.laz")),
     ],
 )
 def test_clip_vpc(

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -60,12 +60,14 @@ def test_clip_vpc(
 ):
     """Test clip vpc to different outputs function"""
 
+    input_data_path = input_path.as_posix() if isinstance(input_path, Path) else input_path
+
     res = subprocess.run(
         [
             utils.pdal_wrench_path(),
             "clip",
             f"--output={output_path.as_posix()}",
-            f"--input={input_path.as_posix()}",
+            f"--input={input_data_path}",
             f"--polygon={utils.test_data_filepath('rectangle.gpkg')}",
         ],
         check=True,

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -44,19 +44,20 @@ def test_input_file_output_file(
 
 
 @pytest.mark.parametrize(
-    "input_path,output_path",
+    "input_path,output_path,points",
     [
-        (utils.test_data_filepath("data.vpc"), utils.test_data_filepath("clipped-vpc.copc.laz")),
-        (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("clipped-vpc-copc-files.vpc")),
-        (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("clipped-vpc-copc-files.copc.laz")),
-        (utils.test_data_filepath("data_copc.vpz"), utils.test_data_filepath("clipped-vpz-copc-files.vpc")),
-        (utils.test_data_filepath("data_copc.vpz"), utils.test_data_filepath("clipped-vpz-copc-files.copc.laz")),
-        ("https://raw.githubusercontent.com/PDAL/wrench/refs/heads/fix-remote-vpc/tests/data/stadium.vpc", utils.test_data_filepath("clipped-vpz-copc-files.copc.laz")),
+        (utils.test_data_filepath("data.vpc"), utils.test_data_filepath("clipped-vpc.copc.laz"), 66911),
+        (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("clipped-vpc-copc-files.vpc"), 66911),
+        (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("clipped-vpc-copc-files.copc.laz"), 66911),
+        (utils.test_data_filepath("data_copc.vpz"), utils.test_data_filepath("clipped-vpz-copc-files.vpc"), 66911),
+        (utils.test_data_filepath("data_copc.vpz"), utils.test_data_filepath("clipped-vpz-copc-files.copc.laz"), 66911),
+        ("https://raw.githubusercontent.com/PDAL/wrench/refs/heads/fix-remote-vpc/tests/data/stadium.vpc", utils.test_data_filepath("clipped-vpz-copc-files.copc.laz"), 66905),
     ],
 )
 def test_clip_vpc(
     input_path: Path,
     output_path: Path,
+    points: int,
 ):
     """Test clip vpc to different outputs function"""
 
@@ -81,4 +82,4 @@ def test_clip_vpc(
 
     number_of_points = pipeline.execute()
 
-    assert number_of_points == 66911
+    assert number_of_points == points


### PR DESCRIPTION
Remote VPC/VPZ files did not work with wrench.  QGIS has a way to read them but trying to use them in operations would end up in an error. This fix bring the same logic as in QGIS into wrench - if VPC/VPZ is remote, download it locally and use from there, while fixing the location of the datasets inside.

Fixes qgis/QGIS#65356 