### PR TITLE
Fix absolute paths detection

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ TODO:
 
 extern int runTile(std::vector<std::string> arglist);  // tile/tile.cpp
 
-std::string WRENCH_VERSION = "1.4.1";
+std::string WRENCH_VERSION = "1.5.0";
 
 void printUsage()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ TODO:
 
 extern int runTile(std::vector<std::string> arglist);  // tile/tile.cpp
 
-std::string WRENCH_VERSION = "1.5.0";
+std::string WRENCH_VERSION = "1.4.1";
 
 void printUsage()
 {

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -271,7 +271,7 @@ void geometryToJson(const Geometry &geom, const BOX3D &bbox, nlohmann::json &jso
     }
 }
 
-bool VirtualPointCloud::write(std::string filename)
+bool VirtualPointCloud::write(std::string filename, bool forceAbsolutePaths)
 {
     if (!isVpcFilename(filename))
         filename += ".vpz";
@@ -288,9 +288,9 @@ bool VirtualPointCloud::write(std::string filename)
     for ( const File &f : files )
     {
         std::string assetFilename;
-        if (pdal::Utils::isRemote(f.filename))
+        if (pdal::Utils::isRemote(f.filename) || forceAbsolutePaths)
         {
-            // keep remote URLs as they are
+            // keep remote URLs or absolute paths as they are
             assetFilename = f.filename;
         }
         else
@@ -379,7 +379,7 @@ bool VirtualPointCloud::write(std::string filename)
         for (size_t i = 0; i < f.overviewFilenames.size(); ++i)
         {
             std::string ovFilename(f.overviewFilenames[i]);
-            if (!pdal::Utils::isRemote(ovFilename))
+            if (!pdal::Utils::isRemote(ovFilename) && !forceAbsolutePaths)
             {
                 const fs::path fRelative = fs::relative(ovFilename, outputPath);
                 ovFilename = "./" + fRelative.string();
@@ -526,6 +526,7 @@ void buildVpc(std::vector<std::string> args)
     int max_threads = -1;
     bool verbose = false;
     bool help = false;
+    bool forceAbsolutePaths = false;
 
     ProgramArgs programArgs;
     programArgs.add("help,h", "Output command help.", help);
@@ -541,6 +542,7 @@ void buildVpc(std::vector<std::string> args)
 
     pdal::Arg& argThreads = programArgs.add("threads", "Max number of concurrent threads for parallel runs", max_threads);
     programArgs.add("verbose", "Print extra debugging output", verbose);
+    programArgs.add("use-absolute-paths", "Store absolute file paths instead of relative paths in the output VPC", forceAbsolutePaths);
 
     try
     {
@@ -914,7 +916,7 @@ void buildVpc(std::vector<std::string> args)
         }
     }
 
-    vpc.write(outputFile);
+    vpc.write(outputFile, forceAbsolutePaths);
 
     // TODO: for now hoping that all files have the same file type + CRS + point format + scaling
     // "dataformat_id"

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -306,7 +306,7 @@ void geometryToJson(const Geometry &geom, const BOX3D &bbox, nlohmann::json &jso
     }
 }
 
-bool VirtualPointCloud::write(std::string filename, bool forceAbsolutePaths)
+bool VirtualPointCloud::write(std::string filename)
 {
     if (!isVpcFilename(filename))
         filename += ".vpz";
@@ -612,7 +612,6 @@ void buildVpc(std::vector<std::string> args)
     int max_threads = -1;
     bool verbose = false;
     bool help = false;
-    bool forceAbsolutePaths = false;
 
     ProgramArgs programArgs;
     programArgs.add("help,h", "Output command help.", help);
@@ -628,7 +627,6 @@ void buildVpc(std::vector<std::string> args)
 
     pdal::Arg& argThreads = programArgs.add("threads", "Max number of concurrent threads for parallel runs", max_threads);
     programArgs.add("verbose", "Print extra debugging output", verbose);
-    programArgs.add("use-absolute-paths", "Store absolute file paths instead of relative paths in the output VPC", forceAbsolutePaths);
 
     try
     {
@@ -1002,7 +1000,7 @@ void buildVpc(std::vector<std::string> args)
         }
     }
 
-    vpc.write(outputFile, forceAbsolutePaths);
+    vpc.write(outputFile);
 
     // TODO: for now hoping that all files have the same file type + CRS + point format + scaling
     // "dataformat_id"

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -284,6 +284,19 @@ bool VirtualPointCloud::write(std::string filename, bool forceAbsolutePaths)
 
     fs::path outputPath = fs::path(filenameAbsolute).parent_path();
 
+    bool forceAbsolutePaths = false;
+    for (const File &f : files) {
+      fs::path fRelative = fs::relative(f.filename, outputPath);
+      if (fRelative.empty()) {
+        forceAbsolutePaths = true;
+        std::cerr << "failed to make filename relative to output path: "
+                  << f.filename 
+                  << " using absolute paths in the output VPC file"
+                  << std::endl;
+        break;
+      }
+    }
+
     std::vector<nlohmann::ordered_json> jFiles;
     for ( const File &f : files )
     {

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -327,7 +327,7 @@ bool VirtualPointCloud::write(std::string filename)
         forceAbsolutePaths = true;
         std::cerr << "Warning: failed to make filename relative to output path: "
                   << f.filename 
-                  << " using absolute paths in the output VPC file"
+                  << " ; using absolute paths in the output VPC file"
                   << std::endl;
         break;
       }
@@ -343,7 +343,7 @@ bool VirtualPointCloud::write(std::string filename)
                 forceAbsolutePaths = true;
                 std::cerr << "Warning: failed to make overview filename relative to output path: "
                         << ovFilename
-                        << " using absolute paths in the output VPC file"
+                        << " ; using absolute paths in the output VPC file"
                         << std::endl;
                 break;
             }

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -285,7 +285,8 @@ bool VirtualPointCloud::write(std::string filename)
     fs::path outputPath = fs::path(filenameAbsolute).parent_path();
 
     bool forceAbsolutePaths = false;
-    for (const File &f : files) {
+    for (const File &f : files) 
+    {
       fs::path fRelative = fs::relative(f.filename, outputPath);
       if (fRelative.empty()) {
         forceAbsolutePaths = true;
@@ -294,6 +295,24 @@ bool VirtualPointCloud::write(std::string filename)
                   << " using absolute paths in the output VPC file"
                   << std::endl;
         break;
+      }
+
+      for (size_t i = 0; i < f.overviewFilenames.size(); ++i)
+      {
+        std::string ovFilename(f.overviewFilenames[i]);
+        if (!pdal::Utils::isRemote(ovFilename)) 
+        {
+            const fs::path fRelative = fs::relative(ovFilename, outputPath);
+            if (fRelative.empty()) 
+            {
+                forceAbsolutePaths = true;
+                std::cerr << "failed to make overview filename relative to output path: "
+                        << ovFilename
+                        << " using absolute paths in the output VPC file"
+                        << std::endl;
+                break;
+            }
+        }
       }
     }
 
@@ -310,15 +329,6 @@ bool VirtualPointCloud::write(std::string filename)
         {
             // turn local paths to relative
             fs::path fRelative = fs::relative(f.filename, outputPath);
-
-            if (fRelative.empty()) {
-              std::cerr << "failed to make filename relative to output path: "
-                        << f.filename 
-                        << " consider using --use-absolute-paths"
-                        << std::endl;
-              return false;
-            }
-
             assetFilename = "./" + fRelative.string();
         }
         std::string fileId = fs::path(f.filename).stem().string();  // TODO: we should make sure the ID is unique
@@ -404,16 +414,6 @@ bool VirtualPointCloud::write(std::string filename)
             if (!pdal::Utils::isRemote(ovFilename) && !forceAbsolutePaths)
             {
                 const fs::path fRelative = fs::relative(ovFilename, outputPath);
-                
-                if (fRelative.empty())
-                {
-                  std::cerr << "failed to make overview filename relative to output path: "
-                            << ovFilename
-                            << " consider using --use-absolute-paths"
-                            << std::endl;
-                  return false;
-                }
-
                 ovFilename = "./" + fRelative.string();
             }
             const std::string key = f.overviewFilenames.size() > 1 ? ("overview-" + std::to_string(i + 1)) : "overview";

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -271,7 +271,7 @@ void geometryToJson(const Geometry &geom, const BOX3D &bbox, nlohmann::json &jso
     }
 }
 
-bool VirtualPointCloud::write(std::string filename, bool forceAbsolutePaths)
+bool VirtualPointCloud::write(std::string filename)
 {
     if (!isVpcFilename(filename))
         filename += ".vpz";
@@ -948,7 +948,7 @@ void buildVpc(std::vector<std::string> args)
         }
     }
 
-    vpc.write(outputFile, forceAbsolutePaths);
+    vpc.write(outputFile);
 
     // TODO: for now hoping that all files have the same file type + CRS + point format + scaling
     // "dataformat_id"

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -574,7 +574,6 @@ void buildVpc(std::vector<std::string> args)
 
     pdal::Arg& argThreads = programArgs.add("threads", "Max number of concurrent threads for parallel runs", max_threads);
     programArgs.add("verbose", "Print extra debugging output", verbose);
-    programArgs.add("use-absolute-paths", "Store absolute file paths instead of relative paths in the output VPC", forceAbsolutePaths);
 
     try
     {

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -325,7 +325,7 @@ bool VirtualPointCloud::write(std::string filename)
       fs::path fRelative = fs::relative(f.filename, outputPath);
       if (fRelative.empty()) {
         forceAbsolutePaths = true;
-        std::cerr << "failed to make filename relative to output path: "
+        std::cerr << "Warning: failed to make filename relative to output path: "
                   << f.filename 
                   << " using absolute paths in the output VPC file"
                   << std::endl;
@@ -341,7 +341,7 @@ bool VirtualPointCloud::write(std::string filename)
             if (fRelative.empty()) 
             {
                 forceAbsolutePaths = true;
-                std::cerr << "failed to make overview filename relative to output path: "
+                std::cerr << "Warning: failed to make overview filename relative to output path: "
                         << ovFilename
                         << " using absolute paths in the output VPC file"
                         << std::endl;

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -558,7 +558,6 @@ void buildVpc(std::vector<std::string> args)
     int max_threads = -1;
     bool verbose = false;
     bool help = false;
-    bool forceAbsolutePaths = false;
 
     ProgramArgs programArgs;
     programArgs.add("help,h", "Output command help.", help);

--- a/src/vpc.cpp
+++ b/src/vpc.cpp
@@ -297,6 +297,15 @@ bool VirtualPointCloud::write(std::string filename, bool forceAbsolutePaths)
         {
             // turn local paths to relative
             fs::path fRelative = fs::relative(f.filename, outputPath);
+
+            if (fRelative.empty()) {
+              std::cerr << "failed to make filename relative to output path: "
+                        << f.filename 
+                        << " consider using --use-absolute-paths"
+                        << std::endl;
+              return false;
+            }
+
             assetFilename = "./" + fRelative.string();
         }
         std::string fileId = fs::path(f.filename).stem().string();  // TODO: we should make sure the ID is unique
@@ -382,6 +391,16 @@ bool VirtualPointCloud::write(std::string filename, bool forceAbsolutePaths)
             if (!pdal::Utils::isRemote(ovFilename) && !forceAbsolutePaths)
             {
                 const fs::path fRelative = fs::relative(ovFilename, outputPath);
+                
+                if (fRelative.empty())
+                {
+                  std::cerr << "failed to make overview filename relative to output path: "
+                            << ovFilename
+                            << " consider using --use-absolute-paths"
+                            << std::endl;
+                  return false;
+                }
+
                 ovFilename = "./" + fRelative.string();
             }
             const std::string key = f.overviewFilenames.size() > 1 ? ("overview-" + std::to_string(i + 1)) : "overview";

--- a/src/vpc.hpp
+++ b/src/vpc.hpp
@@ -75,7 +75,7 @@ struct VirtualPointCloud
     void clear();
     void dump();
     bool read(std::string filename);
-    bool write(std::string filename, bool forceAbsolutePaths = false);
+    bool write(std::string filename);
 
     point_count_t totalPoints() const;
     BOX3D box3d() const;

--- a/src/vpc.hpp
+++ b/src/vpc.hpp
@@ -78,7 +78,7 @@ struct VirtualPointCloud
     void clear();
     void dump();
     bool read(std::string filename);
-    bool write(std::string filename, bool forceAbsolutePaths = false);
+    bool write(std::string filename);
 
     point_count_t totalPoints() const;
     BOX3D box3d() const;

--- a/src/vpc.hpp
+++ b/src/vpc.hpp
@@ -75,7 +75,7 @@ struct VirtualPointCloud
     void clear();
     void dump();
     bool read(std::string filename);
-    bool write(std::string filename);
+    bool write(std::string filename, bool forceAbsolutePaths = false);
 
     point_count_t totalPoints() const;
     BOX3D box3d() const;

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -51,7 +51,7 @@ def test_input_file_output_file(
         (utils.test_data_filepath("data_copc.vpc"), utils.test_data_filepath("clipped-vpc-copc-files.copc.laz"), 66911),
         (utils.test_data_filepath("data_copc.vpz"), utils.test_data_filepath("clipped-vpz-copc-files.vpc"), 66911),
         (utils.test_data_filepath("data_copc.vpz"), utils.test_data_filepath("clipped-vpz-copc-files.copc.laz"), 66911),
-        ("https://raw.githubusercontent.com/PDAL/wrench/f4b156c5081dd9a1d44fccfdb67f2c36e91e3566/tests/data/stadium.vpc", utils.test_data_filepath("clipped-vpz-copc-files.copc.laz"), 66905),
+        ("https://raw.githubusercontent.com/PDAL/wrench/refs/heads/main/tests/data/stadium.vpc", utils.test_data_filepath("clipped-vpz-copc-files.copc.laz"), 66905),
     ],
 )
 def test_clip_vpc(

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1,0 +1,61 @@
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import utils
+
+
+def test_build_vpc_absolute_paths(laz_files):
+    """Paths stored in VPC use absolute paths when --use-absolute-paths is passed."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_vpc = Path(tmp_dir) / "out.vpc"
+
+        res = subprocess.run(
+            [
+                utils.pdal_wrench_path(),
+                "build_vpc",
+                "--use-absolute-paths",
+                f"--output={output_vpc.as_posix()}",
+                *laz_files,
+            ],
+            check=True,
+        )
+
+        assert res.returncode == 0
+        assert output_vpc.exists()
+
+        data = json.loads(output_vpc.read_text())
+        assert data["type"] == "FeatureCollection"
+
+        for feature in data["features"]:
+            for asset in feature["assets"].values():
+                href = asset["href"]
+                assert Path(href).is_absolute(), f"Expected absolute path, got: {href}"
+
+
+def test_build_vpc_relative_paths_default(laz_files):
+    """Paths stored in VPC are relative by default (no --absolute-paths)."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_vpc = Path(tmp_dir) / "out.vpc"
+
+        res = subprocess.run(
+            [
+                utils.pdal_wrench_path(),
+                "build_vpc",
+                f"--output={output_vpc.as_posix()}",
+                *laz_files,
+            ],
+            check=True,
+        )
+
+        assert res.returncode == 0
+        assert output_vpc.exists()
+
+        data = json.loads(output_vpc.read_text())
+        assert data["type"] == "FeatureCollection"
+
+        for feature in data["features"]:
+            data_href = feature["assets"]["data"]["href"]
+            assert data_href.startswith("./"), f"Expected relative path starting with ./, got: {data_href}"

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -7,34 +7,6 @@ import pytest
 import utils
 
 
-def test_build_vpc_absolute_paths(laz_files):
-    """Paths stored in VPC use absolute paths when --use-absolute-paths is passed."""
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        output_vpc = Path(tmp_dir) / "out.vpc"
-
-        res = subprocess.run(
-            [
-                utils.pdal_wrench_path(),
-                "build_vpc",
-                "--use-absolute-paths",
-                f"--output={output_vpc.as_posix()}",
-                *laz_files,
-            ],
-            check=True,
-        )
-
-        assert res.returncode == 0
-        assert output_vpc.exists()
-
-        data = json.loads(output_vpc.read_text())
-        assert data["type"] == "FeatureCollection"
-
-        for feature in data["features"]:
-            for asset in feature["assets"].values():
-                href = asset["href"]
-                assert Path(href).is_absolute(), f"Expected absolute path, got: {href}"
-
-
 def test_build_vpc_relative_paths_default(laz_files):
     """Paths stored in VPC are relative by default (no --absolute-paths)."""
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Fix absolute paths detection

Reworks #91 by removing the `--use-absolute-paths` flag and automatically using absolute paths when relative path cannot be created.